### PR TITLE
Fix data not being read from info files properly

### DIFF
--- a/src/main/IO/InfoFile.cs
+++ b/src/main/IO/InfoFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Godot;
+using System.Collections.Generic;
 
 namespace Jumpvalley.IO
 {
@@ -51,11 +52,16 @@ namespace Jumpvalley.IO
                     if (!string.IsNullOrEmpty(property))
                     {
                         property = property.Trim();
-                        string[] propertyComponents = property.Split(NAME_VALUE_SEPARATOR);
 
-                        if (propertyComponents.Length == 2)
+                        int nameValueSeparatorIndex = property.Find(NAME_VALUE_SEPARATOR);
+                        int propertyValueCharIndex = nameValueSeparatorIndex + NAME_VALUE_SEPARATOR.Length;
+
+                        // Make sure there's content that comes before and after NAME_VALUE_SEPARATOR
+                        if (nameValueSeparatorIndex > 0 && propertyValueCharIndex < property.Length)
                         {
-                            Data[propertyComponents[0]] = propertyComponents[1];
+                            // The part before NAME_VALUE_SEPARATOR should be the property name
+                            // and the part after NAME_VALUE_SEPARATOR should be the property value
+                            Data[property.Substring(0, nameValueSeparatorIndex)] = property.Substring(propertyValueCharIndex);
                         }
                     }
                 }

--- a/src/main/Testing/InfoFileTest.cs
+++ b/src/main/Testing/InfoFileTest.cs
@@ -29,5 +29,17 @@ namespace Jumpvalley.Testing
 
             Console.WriteLine($"Test info file named '{name}' has this data:\n{printedInfoFileData}");
         }
+
+        public static void TestDemoAudioInfoFileV1()
+        {
+            InfoFileTest testInfoFile = new InfoFileTest("""
+				name: Info File OST: The sequel that hopefully doesn't break
+				artists: no one in particular
+				audio_path: audio.ogg
+				audio_url: https://www.example.com
+				""", "test audio file");
+
+            testInfoFile.PrintInfoFileData();
+        }
     }
 }

--- a/src/main/Testing/InfoFileTest.cs
+++ b/src/main/Testing/InfoFileTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Jumpvalley.IO;
+
+namespace Jumpvalley.Testing
+{
+    /// <summary>
+    /// Test class for making sure the <see cref="InfoFile"/> class works properly
+    /// </summary>
+    public partial class InfoFileTest
+    {
+        private InfoFile infoFile;
+        private string name;
+
+        public InfoFileTest(string infoFileText, string infoFileName = "test info file")
+        {
+            infoFile = new InfoFile(infoFileText);
+            name = infoFileName;
+        }
+
+        public void PrintInfoFileData()
+        {
+            string printedInfoFileData = "";
+
+            foreach (KeyValuePair<string, string> property in infoFile.Data)
+            {
+                printedInfoFileData += $"- The '{property.Key}' property has the value '{property.Value}'\n";
+            }
+
+            Console.WriteLine($"Test info file named '{name}' has these contents:\n{printedInfoFileData}");
+        }
+    }
+}

--- a/src/main/Testing/InfoFileTest.cs
+++ b/src/main/Testing/InfoFileTest.cs
@@ -37,7 +37,7 @@ namespace Jumpvalley.Testing
 				artists: no one in particular
 				audio_path: audio.ogg
 				audio_url: https://www.example.com
-				""", "test audio file");
+				""", "test audio info file");
 
             testInfoFile.PrintInfoFileData();
         }

--- a/src/main/Testing/InfoFileTest.cs
+++ b/src/main/Testing/InfoFileTest.cs
@@ -27,7 +27,7 @@ namespace Jumpvalley.Testing
                 printedInfoFileData += $"- The '{property.Key}' property has the value '{property.Value}'\n";
             }
 
-            Console.WriteLine($"Test info file named '{name}' has these contents:\n{printedInfoFileData}");
+            Console.WriteLine($"Test info file named '{name}' has this data:\n{printedInfoFileData}");
         }
     }
 }


### PR DESCRIPTION
This fixes issue #3.

If an info file property had multiple occurrences of ": " (a colon followed by a space) in it, the property value would be read incorrectly. This should no longer occur, so you should now be able to have a property value with a ": " (colon followed by a space) in it, and it should be read properly.