### PR TITLE
Fix some issues with the music system

### DIFF
--- a/src/main/Music/Playlist.cs
+++ b/src/main/Music/Playlist.cs
@@ -70,7 +70,7 @@ namespace Jumpvalley.Music
         public Song CurrentSong
         {
             get => _currentSong;
-            set
+            private set
             {
                 _currentSong = value;
                 OnSongChanged(new SongChangedArgs(value));
@@ -119,6 +119,21 @@ namespace Jumpvalley.Music
         public void Remove(Song s)
         {
             SongList.Remove(s);
+
+            // It makes sense to stop the song if the song being removed
+            // is the one being played.
+            if (s == CurrentSong)
+            {
+                if (SongList.Count > 0)
+                {
+                    // This will still work if there's now only one song in the playlist
+                    PlayNextSong();
+                }
+                else
+                {
+                    StopImmediately();
+                }
+            }
         }
 
         private void CreateAudioStream()
@@ -135,12 +150,12 @@ namespace Jumpvalley.Music
         {
             if (handleSongFinishedConnected)
             {
-                streamPlayer.Finished -= HandleSongFinish;
+                streamPlayer.Finished -= PlayNextSong;
                 handleSongFinishedConnected = false;
             }
         }
 
-        private void HandleSongFinish()
+        private void PlayNextSong()
         {
             // to prevent stack overflow
             if (streamPlayer != null)
@@ -175,7 +190,7 @@ namespace Jumpvalley.Music
             if (!onlyOneSong && streamPlayer != null && handleSongFinishedConnected == false)
             {
                 handleSongFinishedConnected = true;
-                streamPlayer.Finished += HandleSongFinish;
+                streamPlayer.Finished += PlayNextSong;
             }
 
             // take note of the song change


### PR DESCRIPTION
This closes #4 as the issue reported in it seems to no longer occur as of this PR.

This also fixes garbage collection issues with the game's music system.

As of this PR:

- Playlist's `CurrentSong` field can no longer be modified outside of the Playlist class.
- If the song being removed from the playlist is currently playing, the playlist will move onto the next song (if there are any songs left after removal) or stop the playlist. Previously, removing a song from a `Playlist` instance via the class's `Remove` method didn't actually stop the song or fade it out, which is probably why there were issues with switching out the Playlist with another one as well as garbage-collecting the Playlist.