### PR TITLE
Increase physics refresh rate from 60 Hz to 240 Hz

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=3 uid="uid://c7h44u0l74erl"]
+[gd_scene load_steps=44 format=3 uid="uid://c7h44u0l74erl"]
 
 [ext_resource type="Script" path="res://src/main/Program.cs" id="1_y5nob"]
 [ext_resource type="StyleBox" uid="uid://dp7p1icnpuw8n" path="res://styles/bottom_bar/main_menu_btn/normal.tres" id="2_shqk7"]
@@ -14,6 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://dcxkj8m3ltdl8" path="res://addons/kenney_prototype_textures/dark/texture_03.png" id="11_rd65f"]
 [ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="12_3v1qp"]
 [ext_resource type="Material" uid="uid://bm0ukyda3pfcc" path="res://textures/ladder_indicator.tres" id="14_t3s4y"]
+[ext_resource type="Material" uid="uid://bq3d6llinnd1i" path="res://textures/moveable_object_indicator.tres" id="15_2umsb"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_glpat"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -107,6 +108,12 @@ radius = 1.0
 top_radius = 1.0
 bottom_radius = 1.0
 height = 0.5
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_yudit"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_e5b6p"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_qiukw"]
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_y5nob")
@@ -440,6 +447,20 @@ mesh = SubResource("CylinderMesh_h17i4")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.25, 0)
 material_override = ExtResource("14_t3s4y")
 mesh = SubResource("CylinderMesh_h17i4")
+
+[node name="RigidBody3D" type="RigidBody3D" parent="Lobby"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 7.5, -15.5)
+mass = 0.01
+physics_material_override = SubResource("PhysicsMaterial_yudit")
+can_sleep = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Lobby/RigidBody3D"]
+shape = SubResource("BoxShape3D_e5b6p")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Lobby/RigidBody3D/CollisionShape3D"]
+material_override = ExtResource("15_2umsb")
+mesh = SubResource("BoxMesh_qiukw")
+skeleton = NodePath("../..")
 
 [node name="Music" type="Node3D" parent="."]
 

--- a/notes.md
+++ b/notes.md
@@ -38,3 +38,7 @@ https://docs.godotengine.org/en/stable/tutorials/ui/gui_skinning.html
 
 Therefore, to see console output:
 Use the standard ```Console.WriteLine()```, and export the project to an exe with debugging symbols enabled. Then, run the resulting "console.exe" (preferably with a terminal)
+
+### Physics
+
+- Player's (their character's) gravity seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0

--- a/notes.md
+++ b/notes.md
@@ -42,3 +42,4 @@ Use the standard ```Console.WriteLine()```, and export the project to an exe wit
 ### Physics
 
 - Player's (their character's) gravity seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
+    - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference

--- a/notes.md
+++ b/notes.md
@@ -41,5 +41,6 @@ Use the standard ```Console.WriteLine()```, and export the project to an exe wit
 
 ### Physics
 
-- Player's (their character's) gravity seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
-    - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference
+- Player's (their character's) gravity (as in gravitational acceleration) seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
+    - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference in the gravitational acceleration of the box or the player's character
+    - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push

--- a/notes.md
+++ b/notes.md
@@ -42,5 +42,6 @@ Use the standard ```Console.WriteLine()```, and export the project to an exe wit
 ### Physics
 
 - Player's (their character's) gravity (as in gravitational acceleration) seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
-    - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference in the gravitational acceleration of the box or the player's character
-    - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push
+    - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference in the gravitational acceleration of the box or the player's character. Increasing the physics refresh rate from 60 hz or 120 hz to 240 hz does not make a difference either.
+    - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push. Increasing the refresh rate to 240 hz seems to have made physics in Jumpvalley slightly more stable.
+- In Juke's Towers of Hell, the physics refresh rate is 240 hz.

--- a/notes.md
+++ b/notes.md
@@ -43,5 +43,5 @@ Use the standard ```Console.WriteLine()```, and export the project to an exe wit
 
 - Player's (their character's) gravity (as in gravitational acceleration) seems to be the same as a box with a mass of 0.01kg as of Jumpvalley v0.3.0
     - Changing physics refresh rate from 60 hz to 120 hz and vice versa does not seem to make a difference in the gravitational acceleration of the box or the player's character. Increasing the physics refresh rate from 60 hz or 120 hz to 240 hz does not make a difference either.
-    - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push. Increasing the refresh rate to 240 hz seems to have made physics in Jumpvalley slightly more stable.
+    - However, increasing the physics refresh rate from 60 hz to 120 hz has made the box easier to push. Increasing the refresh rate from 120 hz to 240 hz seems to have made physics in Jumpvalley more stable as well.
 - In Juke's Towers of Hell, the physics refresh rate is 240 hz.

--- a/project.godot
+++ b/project.godot
@@ -88,6 +88,8 @@ locale/translations=PackedStringArray("res://strings/bottom_bar.en.translation",
 
 [physics]
 
+common/physics_ticks_per_second=240
+common/max_physics_steps_per_frame=32
 3d/default_gravity=98.1
 common/enable_pause_aware_picking=true
 

--- a/textures/moveable_object_indicator.tres
+++ b/textures/moveable_object_indicator.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://bq3d6llinnd1i"]
+
+[ext_resource type="Texture2D" uid="uid://d0tpyep45doca" path="res://addons/kenney_prototype_textures/light/texture_07.png" id="1_lenl3"]
+
+[resource]
+albedo_color = Color(1, 0.862745, 0.360784, 1)
+albedo_texture = ExtResource("1_lenl3")
+uv1_triplanar = true


### PR DESCRIPTION
This PR increases the number of physics ticks per second in Jumpvalley from 60 to 240.

Input lag seems to have been lowered as a result. This makes sense as input related to character movement no longer has to wait as long as it did before this PR to see its corresponding movement changes made in the next physics update frame.

Another noticeable improvement as a result of this PR is the elimination of jitter (as defined [here](https://docs.godotengine.org/en/stable/tutorials/rendering/jitter_stutter.html)). Your camera would jitter if your character was moving and your *rendering* refresh rate was above 60 Hz. This was due to your *rendering* refresh rate being higher than the *physics* refresh rate. As of this PR, this shouldn't happen anymore (or shouldn't be noticeable anymore) if your *rendering* refresh rate is less than or equal to 240 Hz.

This PR also adds a moveable box that can be pushed around by the player's character. The moveable box is put there to see how increasing refresh rate has affected gravity in Jumpvalley as well as the stability of Godot's physics calculations when running Jumpvalley.

Increasing the physics refresh rate seems to have made physics in Jumpvalley more stable as a result. With 60 Hz physics refresh rate, the moveable box was easily sent flinging by turning your character against the box very rapidly using shift-lock toggling. I couldn't replicate this behavior at 240 Hz.

In addition, the box is much easier to move when the physics refresh rate is 240 Hz instead of 60 Hz.


