### PR TITLE
Replace ProjectSettings.GetSetting usages for physics refresh rate and gravity

### DIFF
--- a/src/main/Levels/Interactives/InteractiveToolkit.cs
+++ b/src/main/Levels/Interactives/InteractiveToolkit.cs
@@ -18,12 +18,12 @@ namespace Jumpvalley.Levels.Interactives
         public static readonly string INTERACTIVE_TYPE_METADATA_NAME = "interactive_type";
 
         /// <summary>
-        /// Returns the current number of physics updates per second based on whatever was defined in project settings
+        /// Returns the current number of physics updates per second
         /// </summary>
         /// <returns>The current number of physics updates per second</returns>
         public static int GetPhysicsTicksPerSecond()
         {
-            return ProjectSettings.GetSettingWithOverride(PROJECT_SETTINGS_PHYSICS_TICKS_PER_SECOND).As<int>();
+            return Engine.MaxFps;
         }
     }
 }

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -278,7 +278,7 @@ namespace Jumpvalley.Players.Movement
         /// <returns></returns>
         public Vector3 GetVelocity(float delta, float yaw)
         {
-            float physicsTicksPerSecond = (float)ProjectSettings.GetSetting(PROJECT_SETTINGS_PHYSICS_TICKS_PER_SECOND);
+            int physicsTicksPerSecond = Engine.PhysicsTicksPerSecond;
 
             // This is needed because while physics steps should occur at constant time intervals,
             // there are slight variances in the actual time passed between each step.

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -117,7 +117,10 @@ namespace Jumpvalley.Players
             RootNode.AddChild(spinner);
 
             // Juke's Towers of Hell physics (or somewhere close) except we're working with meters
-            Mover.Gravity = ProjectSettings.GetSetting("physics/3d/default_gravity").As<float>(); //98.1f;
+            // In-game gravity can be changed at runtime, so we need to account for that. See:
+            // https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-physics-3d-default-gravity
+            // for more details.
+            Mover.Gravity = PhysicsServer3D.AreaGetParam(RootNode.GetViewport().FindWorld3D().Space, PhysicsServer3D.AreaParameter.Gravity).As<float>();
             Mover.JumpVelocity = 25f;
             Mover.Speed = 8f;
 


### PR DESCRIPTION
The ProjectSettings.GetSetting method only returns "compiled" values that the game boots up with. It doesn't take into account values that could be changed at "runtime".

Therefore, the variables for physics refresh rate and gravity have to be accessed in a way that accounts for changes to these variables at runtime.