### PR TITLE
Significantly improve climbing (and add RaycastSweep API along the way)

### DIFF
--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -393,8 +393,17 @@ namespace Jumpvalley.Players.Movement
 
                     climbingRaycastSweep.GlobalPosition = new Vector3(climbingRaycastSweepPos.X, climbedObjectPos.Y, climbingRaycastSweepPos.Z);
 
-                    // Determine the normal of an object we're climbing on
+                    // Determine the 3d object's normal that we're climbing on
                     RaycastSweepResult raycastSweepResult = climbingRaycastSweep.PerformSweep(RaycastSweep.SweepOrder.CenterLeftRight);
+                    Vector3 climbingNormal = raycastSweepResult.Raycast.GetCollisionNormal();
+
+                    // Get the angles we need to compare normal with move direction,
+                    // and do the math as needed according to what was put in the Jumpvalley wiki
+                    // for determining whether or not to climb up in the current frame.
+                    double ladderCollisionAngle = Math.Atan(climbingNormal.Z / climbingNormal.X);
+                    double moveAngle = Math.Atan(moveVector.Z / moveVector.X);
+                    double angleDiff = moveAngle - ladderCollisionAngle;
+                    bool shouldClimbUp = -(Math.PI / 2) < angleDiff && angleDiff < (Math.PI / 2);
 
                     // Discovered a bug while testing: climbing up seems to be a little buggy.
                     // The bug occurs in cases where the player does not hit a climbable object at a perpendicular angle (or somewhere really close).
@@ -407,12 +416,7 @@ namespace Jumpvalley.Players.Movement
                     // While this should probably be fixed, this bug is somewhat miniscule.
                     // This is due to the fact that in Juke's Towers of Hell and games alike,
                     // you can't climb up or down by trying to move left or right when your camera is basically facing the climbable object.
-                    if (
-                        (collisionPoint.X <= characterPos.X && moveVectorX <= 0)
-                        || (collisionPoint.X >= characterPos.X && moveVectorX >= 0)
-                        || (collisionPoint.Z <= characterPos.Z && moveVectorZ <= 0)
-                        || (collisionPoint.Z >= characterPos.Z && moveVectorZ >= 0)
-                        )
+                    if (shouldClimbUp)
                     {
                         climbVelocity = Speed * timingAdjustment;
                     }

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -229,6 +229,7 @@ namespace Jumpvalley.Players.Movement
                         climbingRaycastSweep.StartPosition = new Vector3(-xPos, 0, zPos);
                         climbingRaycastSweep.EndPosition = new Vector3(xPos, 0, zPos);
                         climbingRaycastSweep.RaycastLength = climberHitboxDepth;
+                        climbingRaycastSweep.UpdateRaycastLayout();
                     }
                 }
 
@@ -287,7 +288,7 @@ namespace Jumpvalley.Players.Movement
                 IsClimbing = canClimb;
             };
 
-            climbingRaycastSweep = new RaycastSweep(4, Vector3.Zero, Vector3.Zero, -1f);
+            climbingRaycastSweep = new RaycastSweep(5, Vector3.Zero, Vector3.Zero, -1f);
 
             AddChild(CurrentClimber);
         }

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -174,6 +174,8 @@ namespace Jumpvalley.Players.Movement
             }
         }
 
+        // For climbing stuff
+
         private CharacterBody3D _body = null;
 
         /// <summary>
@@ -223,6 +225,7 @@ namespace Jumpvalley.Players.Movement
                         // Offset by 0.005 meters away from the character hitbox to make sure we don't end up detecting the character hitbox itself
                         float zPos = -(boxShape.Size.Z / 2) - 0.005f;
 
+                        // Remember that the climbing raycast sweep is a child node of the character
                         climbingRaycastSweep.StartPosition = new Vector3(-xPos, 0, zPos);
                         climbingRaycastSweep.EndPosition = new Vector3(xPos, 0, zPos);
                         climbingRaycastSweep.RaycastLength = climberHitboxDepth;
@@ -379,6 +382,15 @@ namespace Jumpvalley.Players.Movement
                     Vector3 characterPos = Body.GlobalPosition;
                     float moveVectorX = moveVector.X;
                     float moveVectorZ = moveVector.Z;
+
+                    // Move raycast sweep's raycasts to have a y-position equal to the y-position of the object currently being climbed,
+                    // to make sure at least one of the raycasts hit the object being climbed.
+                    // We'll also need to change their x and z positions too.
+                    Vector3 climbedObjectPos = CurrentClimber.CurrentlyClimbedObject.GlobalPosition;
+
+                    Vector3 climbingRaycastSweepPos = climbingRaycastSweep.GlobalPosition;
+
+                    climbingRaycastSweep.GlobalPosition = new Vector3(climbingRaycastSweepPos.X, climbedObjectPos.Y, climbingRaycastSweepPos.Z);
 
                     // Determine the normal of an object we're climbing on
                     RaycastSweepResult raycastSweepResult = climbingRaycastSweep.PerformSweep(RaycastSweep.SweepOrder.CenterLeftRight);

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -228,7 +228,7 @@ namespace Jumpvalley.Players.Movement
                         // Remember that the climbing raycast sweep is a child node of the character
                         climbingRaycastSweep.StartPosition = new Vector3(-xPos, 0, zPos);
                         climbingRaycastSweep.EndPosition = new Vector3(xPos, 0, zPos);
-                        climbingRaycastSweep.RaycastLength = climberHitboxDepth;
+                        climbingRaycastSweep.RaycastLength = -climberHitboxDepth;
                         climbingRaycastSweep.UpdateRaycastLayout();
                     }
                 }

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -337,8 +337,6 @@ namespace Jumpvalley.Players.Movement
             bool isOnFloor = IsOnFloor();
             Vector3 moveVector = GetMoveVector(yaw);
 
-            Console.WriteLine($"Move angle at the start: {Math.Atan(moveVector.Z / moveVector.X) / Math.PI}pi");
-
             Vector3 velocity;
 
             if (Body == null)
@@ -371,7 +369,6 @@ namespace Jumpvalley.Players.Movement
 
                 // Remember that "wanting to move forward" while climbing means we want to go up,
                 // and "wanting to move backward" while climbing means we want to go down.
-
                 bool shouldApplyClimbVelocity = true;
 
                 if (ForwardValue == 0 && RightValue == 0)
@@ -380,13 +377,6 @@ namespace Jumpvalley.Players.Movement
                 }
                 else
                 {
-                    // The collision point of the Climber's raycast such that the raycast hit a climbable object
-                    Vector3 collisionPoint = CurrentClimber.RaycastCollisionPoint;
-
-                    Vector3 characterPos = Body.GlobalPosition;
-                    float moveVectorX = moveVector.X;
-                    float moveVectorZ = moveVector.Z;
-
                     // Move raycast sweep's raycasts to have a y-position equal to the y-position of the object currently being climbed,
                     // to make sure at least one of the raycasts hit the object being climbed.
                     // We'll also need to change their x and z positions too.
@@ -405,24 +395,23 @@ namespace Jumpvalley.Players.Movement
                         // Get the angles we need to compare normal with move direction,
                         // and do the math as needed according to what was put in the Jumpvalley wiki
                         // for determining whether or not to climb up in the current frame.
+
+                        // This method for calculating angleDiff doesn't work out too well if
+                        // one angle is in the 1st or 4th quadrant and the other angle is in the 2nd or 3rd quadrant.
+                        /*
                         double ladderCollisionAngle = -Math.Atan(climbingNormal.Z / climbingNormal.X);
                         double moveAngle = Math.Atan(moveVector.Z / moveVector.X);
                         double angleDiff = Math.Abs(moveAngle - ladderCollisionAngle);
                         bool shouldClimbUp = angleDiff <= (Math.PI / 2);
                         Console.WriteLine($"Climbing normal z-coordinate: {climbingNormal.Z}\nClimbing normal x-coordinate: {climbingNormal.X}\nLadder collision angle (after being negated): {ladderCollisionAngle / Math.PI}pi");
                         Console.WriteLine($"Move angle: {moveAngle/Math.PI}pi\nAngle difference: {angleDiff/Math.PI}pi\nShould climb up: {shouldClimbUp.ToString()}");
+                        */
 
-                        // Discovered a bug while testing: climbing up seems to be a little buggy.
-                        // The bug occurs in cases where the player does not hit a climbable object at a perpendicular angle (or somewhere really close).
-                        // In this case, one of the conditions that compare a collision point coordinate with the character's position coordinate could always be true.
-                        //
-                        // For example, assume your character's yaw angle is -0.05 radians when your character gets into climbing position.
-                        // In this case, the x-coordinate of the collision point will always be greater than the character's position x-coordinate until the collision point moves.
-                        // Because of this, if you tried to move right, you would climb up.
-                        //
-                        // While this should probably be fixed, this bug is somewhat miniscule.
-                        // This is due to the fact that in Juke's Towers of Hell and games alike,
-                        // you can't climb up or down by trying to move left or right when your camera is basically facing the climbable object.
+                        // Apparently, Godot's Vector3.SignedAngleTo method exists, making this much easier to implement.
+                        float angleDiff = climbingNormal.Rotated(Vector3.Up, (float)Math.PI).SignedAngleTo(moveVector, Vector3.Up);
+                        //Console.WriteLine($"Angle difference: {angleDiff/Math.PI}pi");
+                        bool shouldClimbUp = Math.Abs(angleDiff) <= (Math.PI / 2);
+
                         if (shouldClimbUp)
                         {
                             climbVelocity = Speed * timingAdjustment;
@@ -442,32 +431,6 @@ namespace Jumpvalley.Players.Movement
                             }
                         }
                     }
-
-                    /*
-                    // For some reason, the reverse of the above is true (this is likely a bug), so the sign is switched from greater than to less than for now.
-                    if (ForwardValue < 0)
-                    {
-                        climbVelocity = Speed * timingAdjustment;
-                    }
-                    else if (ForwardValue == 0)
-                    {
-                        climbVelocity = 0;
-                    }
-                    else
-                    {
-                        if (isOnFloor)
-                        {
-                            // If we're already on the floor, move like we're walking on the floor.
-                            velocity.Y = 0;
-                            climbVelocity = 0;
-                            shouldApplyClimbVelocity = false;
-                        }
-                        else
-                        {
-                            climbVelocity = -Speed * timingAdjustment;
-                        }
-                    }
-                    */
                 }
 
                 if (shouldApplyClimbVelocity)

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -225,7 +225,7 @@ namespace Jumpvalley.Players.Movement
 
                         climbingRaycastSweep.StartPosition = new Vector3(-xPos, 0, zPos);
                         climbingRaycastSweep.EndPosition = new Vector3(xPos, 0, zPos);
-
+                        climbingRaycastSweep.RaycastLength = climberHitboxDepth;
                     }
                 }
 

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -551,7 +551,7 @@ namespace Jumpvalley.Players.Movement
                     // the direction of the character should be determined by the yaw corresponding to the move vector
                     // relative to the camera yaw.
                     rotator.Yaw = GetYaw() + (float)Math.Atan2(-RightValue, -ForwardValue);
-                    rotator.GradualTurnEnabled = !IsClimbing;
+                    rotator.GradualTurnEnabled = IsJumping || (!IsClimbing);
                     rotator.Update(delta);
                 }
             }

--- a/src/main/Players/Movement/BaseMover.cs
+++ b/src/main/Players/Movement/BaseMover.cs
@@ -1,5 +1,6 @@
 ﻿using Godot;
 using Jumpvalley.Players.Camera;
+using Jumpvalley.Raycasting;
 using System;
 
 namespace Jumpvalley.Players.Movement
@@ -186,12 +187,26 @@ namespace Jumpvalley.Players.Movement
                 _body = value;
 
                 BodyRotator rotator = Rotator;
+                Climber climber = CurrentClimber;
+
+                if (climbingRaycastSweep != null)
+                {
+                    climbingRaycastSweep.Dispose();
+                    climbingRaycastSweep = null;
+                }
+
+                if (value == null)
+                {
+                    rotator.Body = null;
+                    climber.Hitbox = null;
+                    return;
+                }
+
                 if (rotator != null)
                 {
                     rotator.Body = value;
                 }
-
-                Climber climber = CurrentClimber;
+                
                 if (climber != null)
                 {
                     climber.Hitbox = value.GetNode<CollisionShape3D>(CHARACTER_ROOT_COLLIDER_NAME);
@@ -229,6 +244,11 @@ namespace Jumpvalley.Players.Movement
         /// The <see cref="Climber"/> that's currently in charge of determining whether or not the character can climb at the current physics frame.
         /// </summary>
         public Climber CurrentClimber { get; private set; }
+
+        /// <summary>
+        /// Raycast sweep used to grab the normal of an object that the player is climbing on
+        /// </summary>
+        private RaycastSweep climbingRaycastSweep;
 
         public BaseMover()
         {

--- a/src/main/Players/Movement/Climber.cs
+++ b/src/main/Players/Movement/Climber.cs
@@ -123,7 +123,7 @@ namespace Jumpvalley.Players.Movement
             if (collisionBox == null) return;
 
             Vector3 hitboxSize = collisionBox.Size;
-            areaBox.Size = new Vector3(0.2f, hitboxSize.Y / 2, 0.1f);
+            areaBox.Size = new Vector3(0.25f, hitboxSize.Y / 2, 0.1f);
 
             // Remember, position of the area is relative to the position of the hitbox.
             area.Position = new Vector3(0, -hitboxSize.Y / 4, -hitboxSize.Z / 2 - areaBox.Size.Z / 2);

--- a/src/main/Players/Movement/Climber.cs
+++ b/src/main/Players/Movement/Climber.cs
@@ -81,6 +81,18 @@ namespace Jumpvalley.Players.Movement
         }
 
         /// <summary>
+        /// The width of the climbing hitbox.
+        /// This length is parallel to the x-axis that's relative to the position and rotation of the character's hitbox.
+        /// </summary>
+        public float HitboxWidth = 0.25f;
+
+        /// <summary>
+        /// The depth of the climbing hitbox.
+        /// This length is parallel to the z-axis that's relative to the position and rotation of the character's hitbox.
+        /// </summary>
+        public float HitboxDepth = 0.1f;
+
+        /// <summary>
         /// Creates a new instance of <see cref="Climber"/>
         /// </summary>
         public Climber(CollisionShape3D hitbox)
@@ -123,7 +135,7 @@ namespace Jumpvalley.Players.Movement
             if (collisionBox == null) return;
 
             Vector3 hitboxSize = collisionBox.Size;
-            areaBox.Size = new Vector3(0.25f, hitboxSize.Y / 2, 0.1f);
+            areaBox.Size = new Vector3(HitboxWidth, hitboxSize.Y / 2, HitboxDepth);
 
             // Remember, position of the area is relative to the position of the hitbox.
             area.Position = new Vector3(0, -hitboxSize.Y / 4, -hitboxSize.Z / 2 - areaBox.Size.Z / 2);

--- a/src/main/Players/Movement/Climber.cs
+++ b/src/main/Players/Movement/Climber.cs
@@ -90,7 +90,7 @@ namespace Jumpvalley.Players.Movement
         /// The depth of the climbing hitbox.
         /// This length is parallel to the z-axis that's relative to the position and rotation of the character's hitbox.
         /// </summary>
-        public float HitboxDepth = 0.1f;
+        public float HitboxDepth = 0.2f;
 
         /// <summary>
         /// Creates a new instance of <see cref="Climber"/>

--- a/src/main/Players/Movement/Climber.cs
+++ b/src/main/Players/Movement/Climber.cs
@@ -10,11 +10,14 @@ namespace Jumpvalley.Players.Movement
     public partial class Climber : Node, IDisposable
     {
         /// <summary>
-        /// Name of the metadata entry that specifies whether or not a PhysicsBody3D is climbable
+        /// Name of the metadata entry that specifies whether or not a <see cref="PhysicsBody3D"/> is climbable
         /// </summary>
         public readonly string IS_CLIMBABLE_METADATA_NAME = "is_climbable";
 
-        private RayCast3D rayCast;
+        /// <summary>
+        /// The <see cref="Area3D"/> that allows the character to climb when a climbable PhysicsBody3D is intersecting with it
+        /// </summary>
+        private Area3D area;
 
         private bool _canClimb = false;
 
@@ -60,14 +63,14 @@ namespace Jumpvalley.Players.Movement
                 CollisionShape3D oldHitbox = _hitbox;
                 if (oldHitbox != null)
                 {
-                    oldHitbox.RemoveChild(rayCast);
+                    oldHitbox.RemoveChild(area);
                 }
 
                 _hitbox = value;
                 
                 if (value != null)
                 {
-                    value.AddChild(rayCast);
+                    value.AddChild(area);
                 }
             }
         }
@@ -79,9 +82,8 @@ namespace Jumpvalley.Players.Movement
         {
             Name = $"{nameof(Climber)}_{GetHashCode()}";
 
-            rayCast = new RayCast3D();
-            rayCast.Name = $"{nameof(Climber)}_{GetHashCode()}_{nameof(rayCast)}";
-            rayCast.HitFromInside = true;
+            area = new Area3D();
+            area.Name = $"{nameof(Climber)}_{GetHashCode()}_{nameof(area)}";
 
             Hitbox = hitbox;
 

--- a/src/main/Players/Movement/Climber.cs
+++ b/src/main/Players/Movement/Climber.cs
@@ -19,6 +19,11 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         private Area3D area;
 
+        /// <summary>
+        /// The box that defines <see cref="area"/>'s region
+        /// </summary>
+        private BoxShape3D areaBox;
+
         private bool _canClimb = false;
 
         /// <summary>
@@ -85,6 +90,12 @@ namespace Jumpvalley.Players.Movement
             area = new Area3D();
             area.Name = $"{nameof(Climber)}_{GetHashCode()}_{nameof(area)}";
 
+            areaBox = new BoxShape3D();
+
+            CollisionShape3D areaShape = new CollisionShape3D();
+            areaShape.Shape = areaBox;
+            area.AddChild(areaShape);
+
             Hitbox = hitbox;
 
             updateRayCast();
@@ -96,8 +107,8 @@ namespace Jumpvalley.Players.Movement
         public new void Dispose()
         {
             QueueFree();
-            rayCast.QueueFree();
-            rayCast.Dispose();
+            area.QueueFree();
+            area.Dispose();
             base.Dispose();
         }
 
@@ -118,6 +129,23 @@ namespace Jumpvalley.Players.Movement
             // as it is parented to the hitbox itself
             rayCast.Position = new Vector3(0, 0, -boxSize.Z / 2 - 0.05f);
             rayCast.TargetPosition = new Vector3(0, -boxSize.Y / 2, 0);
+        }
+
+        private void updateArea()
+        {
+            CollisionShape3D hitbox = Hitbox;
+            if (hitbox == null) return;
+
+            BoxShape3D collisionBox = hitbox.Shape as BoxShape3D;
+
+            // For now, only box-shaped hitboxes will work.
+            if (collisionBox == null) return;
+
+            Vector3 hitboxSize = collisionBox.Size;
+            areaBox.Size = new Vector3(0.2f, hitboxSize.Y / 2, 0.1f);
+
+            // Remember, position of the area is relative to the position of the hitbox.
+            area.Position = new Vector3(0, -hitboxSize.Y / 4, -hitboxSize.Z / 2 - areaBox.Size.Z / 2);
         }
 
         public override void _PhysicsProcess(double delta)

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -181,7 +181,7 @@ namespace Jumpvalley.Players
 
             // test RaycastSweep
             RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
-            RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character);
+            RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.LeftToRight);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
             RootNode.AddChild(raycastSweepTest);
 

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Godot;
 
 using Jumpvalley.Music;
@@ -180,12 +181,23 @@ namespace Jumpvalley.Players
             levelLoadingTest.Start();
 
             // test RaycastSweep
-            /*
             RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
-            RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.LeftToRight);
+            RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.CenterLeftRight);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
             RootNode.AddChild(raycastSweepTest);
-            */
+            Disposables.Add(raycastSweep);
+
+            Task.Run(() => {
+                Console.WriteLine("Starting with 3 raycasts. Increasing to 12 raycasts in 5 seconds.");
+                Task.Delay(5000);
+                for (int i = 0; i < 9; i++)
+                {
+                    Console.WriteLine("Adding a raycast");
+                    raycastSweep.NumRaycasts += 1;
+                    raycastSweep.UpdateRaycastLayout();
+                    Task.Delay(500);
+                }
+            });
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -181,12 +181,13 @@ namespace Jumpvalley.Players
             levelLoadingTest.Start();
 
             // test RaycastSweep
-            RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
+            RaycastSweep raycastSweep = new RaycastSweep(8, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
             RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.CenterLeftRight);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
             RootNode.AddChild(raycastSweepTest);
             Disposables.Add(raycastSweep);
 
+            /*
             void IncrementNumRaycasts()
             {
                 Console.WriteLine("Adding a raycast");
@@ -206,6 +207,7 @@ namespace Jumpvalley.Players
                     System.Threading.Thread.Sleep(500);
                 }
             });
+            */
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -181,7 +181,8 @@ namespace Jumpvalley.Players
 
             // test RaycastSweep
             RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, 0.25f), new Vector3(0.5f, 0f, 0.25f));
-            Character.AddChild(raycastSweep);
+            RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character);
+            PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -187,7 +187,7 @@ namespace Jumpvalley.Players
             RootNode.AddChild(raycastSweepTest);
             Disposables.Add(raycastSweep);
 
-            async void IncrementNumRaycasts()
+            void IncrementNumRaycasts()
             {
                 Console.WriteLine("Adding a raycast");
                 raycastSweep.NumRaycasts += 1;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -181,11 +181,13 @@ namespace Jumpvalley.Players
             levelLoadingTest.Start();
 
             // test RaycastSweep
+            /*
             RaycastSweep raycastSweep = new RaycastSweep(8, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
             RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.CenterLeftRight);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
             RootNode.AddChild(raycastSweepTest);
             Disposables.Add(raycastSweep);
+            */
 
             /*
             void IncrementNumRaycasts()

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -180,9 +180,10 @@ namespace Jumpvalley.Players
             levelLoadingTest.Start();
 
             // test RaycastSweep
-            RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, 0.25f), new Vector3(0.5f, 0f, 0.25f));
+            RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
             RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
+            RootNode.AddChild(raycastSweepTest);
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -180,10 +180,12 @@ namespace Jumpvalley.Players
             levelLoadingTest.Start();
 
             // test RaycastSweep
+            /*
             RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, -0.251f), new Vector3(0.5f, 0f, -0.251f), -1f);
             RaycastSweepTest raycastSweepTest = new RaycastSweepTest(raycastSweep, Character, RaycastSweep.SweepOrder.LeftToRight);
             PrimaryGui.AddChild(raycastSweepTest.RaycastResultLabel);
             RootNode.AddChild(raycastSweepTest);
+            */
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -7,6 +7,7 @@ using Jumpvalley.Players.Camera;
 using Jumpvalley.Players.Controls;
 using Jumpvalley.Players.Gui;
 using Jumpvalley.Players.Movement;
+using Jumpvalley.Raycasting;
 using Jumpvalley.Testing;
 
 namespace Jumpvalley.Players
@@ -177,6 +178,10 @@ namespace Jumpvalley.Players
                 );
             Disposables.Add(levelLoadingTest);
             levelLoadingTest.Start();
+
+            // test RaycastSweep
+            RaycastSweep raycastSweep = new RaycastSweep(3, new Vector3(-0.5f, 0f, 0.25f), new Vector3(0.5f, 0f, 0.25f));
+            Character.AddChild(raycastSweep);
 
             RenderFramerateLimiter fpsLimiter = new RenderFramerateLimiter();
             fpsLimiter.MinFpsDifference = 0;

--- a/src/main/Players/Player.cs
+++ b/src/main/Players/Player.cs
@@ -187,15 +187,23 @@ namespace Jumpvalley.Players
             RootNode.AddChild(raycastSweepTest);
             Disposables.Add(raycastSweep);
 
+            async void IncrementNumRaycasts()
+            {
+                Console.WriteLine("Adding a raycast");
+                raycastSweep.NumRaycasts += 1;
+                raycastSweep.UpdateRaycastLayout();
+            }
+
             Task.Run(() => {
                 Console.WriteLine("Starting with 3 raycasts. Increasing to 12 raycasts in 5 seconds.");
-                Task.Delay(5000);
+                System.Threading.Thread.Sleep(5000);
                 for (int i = 0; i < 9; i++)
                 {
-                    Console.WriteLine("Adding a raycast");
-                    raycastSweep.NumRaycasts += 1;
-                    raycastSweep.UpdateRaycastLayout();
-                    Task.Delay(500);
+                    // Workaround due to Godot not letting you add nodes to scene tree in a background thread at the moment:
+                    // https://docs.godotengine.org/en/stable/classes/class_callable.html#class-callable-method-call-deferred
+                    // https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_differences.html#doc-c-sharp-differences
+                    Callable.From(IncrementNumRaycasts).CallDeferred();
+                    System.Threading.Thread.Sleep(500);
                 }
             });
 

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -96,6 +96,7 @@ namespace Jumpvalley.Raycasting
             for (int i = 0; i < Raycasts.Count; i++)
             {
                 RayCast3D r = Raycasts[i];
+
                 // Needed since the raycast collision information doesn't update every frame by default
                 // (which is for performance reasons)
                 r.ForceRaycastUpdate();

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -149,7 +149,9 @@ namespace Jumpvalley.Raycasting
             foreach (RayCast3D r in Raycasts)
             {
                 r.Position = currentStartPos;
-                r.TargetPosition = new Vector3(currentStartPos.X, currentStartPos.Y, currentStartPos.Z + raycastLength);
+
+                // Remember that target position is relative to the position of the *raycast itself*.
+                r.TargetPosition = new Vector3(0, 0, raycastLength);
 
                 AddChild(r);
 

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -1,11 +1,13 @@
 ﻿using Godot;
+using System;
+using System.Collections.Generic;
 
 namespace Jumpvalley.Raycasting
 {
     /// <summary>
     /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.
     /// </summary>
-    public partial class RaycastSweep
+    public partial class RaycastSweep: Node3D
     {
         /// <summary>
         /// The total number of raycasts that the raycast sweep will perform from the start position to the end position.
@@ -13,14 +15,26 @@ namespace Jumpvalley.Raycasting
         public int NumRaycasts { get; private set; }
 
         /// <summary>
-        /// The starting position of the raycast sweep. This is where the first raycast will begin.
+        /// The length in meters that each raycast in the <see cref="RaycastSweep"/> should extend in the relative Z-axis of this <see cref="Node3D"/>
+        /// </summary>
+        public float RaycastLength { get; private set; }
+
+        /// <summary>
+        /// The starting position of the raycast sweep.
+        /// This position is relative to the position of this <see cref="Node3D"/> and is where the first raycast will begin.
         /// </summary>
         public Vector3 StartPosition { get; private set; }
 
         /// <summary>
-        /// The ending position of the raycast sweep. This is where the last raycast will begin.
+        /// The ending position of the raycast sweep.
+        /// This position is relative to the position of this <see cref="Node3D"/> and is where the last raycast will begin.
         /// </summary>
         public Vector3 EndPosition { get; private set; }
+
+        /// <summary>
+        /// The raycasts being used by the <see cref="RaycastSweep"/>.
+        /// </summary>
+        public List<RayCast3D> Raycasts { get; private set; }
 
         /// <summary>
         /// Creates a new <see cref="RaycastSweep"/> with the given raycast count, starting position, and ending position
@@ -30,9 +44,30 @@ namespace Jumpvalley.Raycasting
         /// <param name="endPosition"></param>
         public RaycastSweep(int numRaycasts, Vector3 startPosition, Vector3 endPosition)
         {
+            if (numRaycasts < 2) throw new ArgumentOutOfRangeException("numRaycasts", "RaycastSweep requires that there are at least 2 raycasts to work with.");
+
+            Name = $"{nameof(RaycastSweep)}_{GetHashCode()}";
+
             NumRaycasts = numRaycasts;
             StartPosition = startPosition;
             EndPosition = endPosition;
+
+            Vector3 positionDifference = endPosition - startPosition;
+            float posDifferenceLength = positionDifference.Length();
+
+            // posIncrement is the position difference between each raycast. 
+            // We want to cover the entire raycasting range as defined by startPosition and endPosition,
+            // so we'll need to set the position increment in a way that allows for the full raycasting range
+            // to be covered and allows for the raycasts to be equally spaced from each other.
+            float posIncrement = posDifferenceLength / (numRaycasts - 1);
+            Vector3 currentStartPos = startPosition;
+            for (int i = 0; i < numRaycasts; i++)
+            {
+                RayCast3D r = new RayCast3D();
+                r.Name = $"";
+                r.Position = currentStartPos;
+                
+            }
         }
     }
 }

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -170,9 +170,9 @@ namespace Jumpvalley.Raycasting
                         }
                     }
                 }
-                else
+                else if (order == SweepOrder.CenterRightLeft)
                 {
-                    for (int i = numRaycasts - 1; i > -1; i++)
+                    for (int i = numRaycasts - 1; i > -1; i--)
                     {
                         if (i != centerIndex)
                         {
@@ -194,7 +194,7 @@ namespace Jumpvalley.Raycasting
                 }
                 else if (order == SweepOrder.RightToLeft)
                 {
-                    for (int i = numRaycasts - 1; i > -1; i++)
+                    for (int i = numRaycasts - 1; i > -1; i--)
                     {
                         RaycastSweepResult result = GetCurrentRaycastCollisionInfo(Raycasts[i], i);
                         if (result != null) return result;

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -7,7 +7,7 @@ namespace Jumpvalley.Raycasting
     /// <summary>
     /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.
     /// </summary>
-    public partial class RaycastSweep: Node3D
+    public partial class RaycastSweep: Node3D, IDisposable
     {
         /// <summary>
         /// The total number of raycasts that the raycast sweep will perform from the start position to the end position.
@@ -59,15 +59,39 @@ namespace Jumpvalley.Raycasting
             // We want to cover the entire raycasting range as defined by startPosition and endPosition,
             // so we'll need to set the position increment in a way that allows for the full raycasting range
             // to be covered and allows for the raycasts to be equally spaced from each other.
-            float posIncrement = posDifferenceLength / (numRaycasts - 1);
+            Vector3 posIncrement = positionDifference / (numRaycasts - 1);
             Vector3 currentStartPos = startPosition;
             for (int i = 0; i < numRaycasts; i++)
             {
+                // Create raycast for the current index
                 RayCast3D r = new RayCast3D();
-                r.Name = $"";
+                r.Name = $"Raycast{i}";
                 r.Position = currentStartPos;
-                
+                r.TargetPosition = new Vector3(currentStartPos.X, currentStartPos.Y, currentStartPos.Z + RaycastLength);
+
+                AddChild(r);
+                Raycasts.Add(r);
+
+                // Move onto the next raycast with an updated start position
+                currentStartPos += posIncrement;
             }
+        }
+
+        /// <summary>
+        /// Disposes of this <see cref="RaycastSweep"/>, including its raycasts.
+        /// </summary>
+        public new void Dispose()
+        {
+            QueueFree();
+
+            foreach (RayCast3D r in Raycasts)
+            {
+                r.QueueFree();
+                r.Dispose();
+            }
+            Raycasts.Clear();
+
+            base.Dispose();
         }
     }
 }

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -66,7 +66,11 @@ namespace Jumpvalley.Raycasting
                 // Create raycast for the current index
                 RayCast3D r = new RayCast3D();
                 r.Name = $"Raycast{i}";
+
+                // For performance reasons, we don't want to update every physics frame by default.
+                // This is because we really only need to update when PerformRaycast() is called.
                 r.Enabled = false;
+
                 r.Position = currentStartPos;
                 r.TargetPosition = new Vector3(currentStartPos.X, currentStartPos.Y, currentStartPos.Z + RaycastLength);
 
@@ -76,6 +80,31 @@ namespace Jumpvalley.Raycasting
                 // Move onto the next raycast with an updated start position
                 currentStartPos += posIncrement;
             }
+        }
+
+        /// <summary>
+        /// Runs through the raycasts in <see cref="Raycasts"/> from left-to-right.
+        /// This returns raycast collision information about the first raycast in <see cref="Raycasts"/>
+        /// that got collided with. If no raycast in <see cref="Raycasts"/> was hit,
+        /// this function returns null.
+        /// </summary>
+        /// <returns>The results of this raycast operation</returns>
+        public RaycastSweepResult PerformRaycast()
+        {
+            for (int i = 0; i < Raycasts.Count; i++)
+            {
+                RayCast3D r = Raycasts[i];
+                // Needed since the raycast collision information doesn't update every frame by default
+                // (which is for performance reasons)
+                r.ForceRaycastUpdate();
+
+                if (r.IsColliding())
+                {
+                    return new RaycastSweepResult(r, r.GetCollisionPoint(), r.GetCollider(), i);
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -42,7 +42,7 @@ namespace Jumpvalley.Raycasting
         /// <param name="numRaycasts"></param>
         /// <param name="startPosition"></param>
         /// <param name="endPosition"></param>
-        public RaycastSweep(int numRaycasts, Vector3 startPosition, Vector3 endPosition)
+        public RaycastSweep(int numRaycasts, Vector3 startPosition, Vector3 endPosition, float raycastLength)
         {
             if (numRaycasts < 2) throw new ArgumentOutOfRangeException("numRaycasts", "RaycastSweep requires that there are at least 2 raycasts to work with.");
 
@@ -51,6 +51,8 @@ namespace Jumpvalley.Raycasting
             NumRaycasts = numRaycasts;
             StartPosition = startPosition;
             EndPosition = endPosition;
+            RaycastLength = raycastLength;
+            Raycasts = new List<RayCast3D>();
 
             Vector3 positionDifference = endPosition - startPosition;
             float posDifferenceLength = positionDifference.Length();
@@ -69,7 +71,10 @@ namespace Jumpvalley.Raycasting
 
                 // For performance reasons, we don't want to update every physics frame by default.
                 // This is because we really only need to update when PerformRaycast() is called.
-                r.Enabled = false;
+                //r.Enabled = false;
+
+                // Using ForceRaycastUpdate() seems to be buggy, so we need to keep this for now.
+                r.Enabled = true;
 
                 r.Position = currentStartPos;
                 r.TargetPosition = new Vector3(currentStartPos.X, currentStartPos.Y, currentStartPos.Z + RaycastLength);
@@ -88,7 +93,7 @@ namespace Jumpvalley.Raycasting
         /// <br/>
         /// This returns raycast collision information about the first raycast in <see cref="Raycasts"/>
         /// that got collided with. If no raycast in <see cref="Raycasts"/> was hit,
-        /// this function returns null.
+        /// this method returns null.
         /// </summary>
         /// <returns>The results of this raycast operation</returns>
         public RaycastSweepResult PerformRaycast()
@@ -99,7 +104,8 @@ namespace Jumpvalley.Raycasting
 
                 // Needed since the raycast collision information doesn't update every frame by default
                 // (which is for performance reasons)
-                r.ForceRaycastUpdate();
+                // Currently not using this method since this seems to be buggy.
+                //r.ForceRaycastUpdate();
 
                 if (r.IsColliding())
                 {

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -14,7 +14,7 @@ namespace Jumpvalley.Raycasting
     public partial class RaycastSweep : Node3D, IDisposable
     {
         /// <summary>
-        /// List of possible orders in which RaycastSweep can iterate over its raycasts when <see cref="PerformRaycast"/> is called
+        /// List of possible orders in which RaycastSweep can iterate over its raycasts when <see cref="PerformSweep"/> is called
         /// </summary>
         public enum SweepOrder
         {
@@ -132,7 +132,7 @@ namespace Jumpvalley.Raycasting
                     r.Name = $"Raycast{Raycasts.Count}";
 
                     // For performance reasons, we don't want to update every physics frame by default.
-                    // This is because we really only need to update when PerformRaycast() is called.
+                    // This is because we really only need to update when PerformSweep() is called.
                     //r.Enabled = false;
 
                     // Using ForceRaycastUpdate() seems to be buggy, so we need to keep this for now.
@@ -190,12 +190,18 @@ namespace Jumpvalley.Raycasting
         /// <br/>
         /// <br/>
         /// This returns raycast collision information about the first raycast in <see cref="Raycasts"/>
-        /// that got collided with. If no raycast in <see cref="Raycasts"/> was hit,
-        /// this method returns null.
+        /// that got collided with.
+        /// <br/>
+        /// <br/>
+        /// Because multiple raycasts in the raycast sweep could be colliding with something at the same time,
+        /// whichever counts as the "first" raycast to hit something depends on the SweepOrder specified in <paramref name="order"/>.
+        /// <br/>
+        /// <br/>
+        /// If no raycast in <see cref="Raycasts"/> is currently hitting something, this method returns null.
         /// </summary>
         /// <param name="order">The order in which to run through the raycasts</param>
         /// <returns>The results of this raycast operation</returns>
-        public RaycastSweepResult PerformRaycast(SweepOrder order)
+        public RaycastSweepResult PerformSweep(SweepOrder order)
         {
             int numRaycasts = Raycasts.Count;
 

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -1,9 +1,4 @@
 ﻿using Godot;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Jumpvalley.Raycasting
 {
@@ -27,9 +22,17 @@ namespace Jumpvalley.Raycasting
         /// </summary>
         public Vector3 EndPosition { get; private set; }
 
-        public RaycastSweep()
+        /// <summary>
+        /// Creates a new <see cref="RaycastSweep"/> with the given raycast count, starting position, and ending position
+        /// </summary>
+        /// <param name="numRaycasts"></param>
+        /// <param name="startPosition"></param>
+        /// <param name="endPosition"></param>
+        public RaycastSweep(int numRaycasts, Vector3 startPosition, Vector3 endPosition)
         {
-
+            NumRaycasts = numRaycasts;
+            StartPosition = startPosition;
+            EndPosition = endPosition;
         }
     }
 }

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -125,7 +125,7 @@ namespace Jumpvalley.Raycasting
                 {
                     // Create raycast for the current index
                     RayCast3D r = new RayCast3D();
-                    r.Name = $"Raycast{i}";
+                    r.Name = $"Raycast{Raycasts.Count}";
 
                     // For performance reasons, we don't want to update every physics frame by default.
                     // This is because we really only need to update when PerformRaycast() is called.

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -66,6 +66,7 @@ namespace Jumpvalley.Raycasting
                 // Create raycast for the current index
                 RayCast3D r = new RayCast3D();
                 r.Name = $"Raycast{i}";
+                r.Enabled = false;
                 r.Position = currentStartPos;
                 r.TargetPosition = new Vector3(currentStartPos.X, currentStartPos.Y, currentStartPos.Z + RaycastLength);
 

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -8,11 +8,8 @@ namespace Jumpvalley.Raycasting
     /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.
     /// <br/>
     /// <br/>
-    /// The center raycast, being located in the middle, is the one assigned to the median index (index in the middle) (for example: 0, 1, 2, 3, ..., n - 1; where n is the number of raycasts).
-    /// <br/>
-    /// <br/>
-    /// If the number of raycasts is an even number, meaning that there's two indexes in the middle, the lower index will be the center index and the one corresponding to the center raycast.
-    /// For this reason, it's recommended that you use an odd number of raycasts if you really want the raycast sweep to start from the center (since there'll only be one index in the middle).
+    /// The center raycast, being located in the middle (or close to it), is assigned to the greatest integer that's less than or equal to the median index.
+    /// "index" here refers to the numerical index that a raycast is located in within a raycast sweep from left to right.
     /// </summary>
     public partial class RaycastSweep : Node3D, IDisposable
     {

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jumpvalley.Raycasting
+{
+    /// <summary>
+    /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.
+    /// </summary>
+    public partial class RaycastSweep
+    {
+    }
+}

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -6,6 +6,13 @@ namespace Jumpvalley.Raycasting
 {
     /// <summary>
     /// Sweeps over a region of 3D space using a series of equally-spaced-out raycasts.
+    /// <br/>
+    /// <br/>
+    /// The center raycast, being located in the middle, is the one assigned to the median index (index in the middle) (for example: 0, 1, 2, 3, ..., n - 1; where n is the number of raycasts).
+    /// <br/>
+    /// <br/>
+    /// If the number of raycasts is an even number, meaning that there's two indexes in the middle, the lower index will be the center index and the one corresponding to the center raycast.
+    /// For this reason, it's recommended that you use an odd number of raycasts if you really want the raycast sweep to start from the center (since there'll only be one index in the middle).
     /// </summary>
     public partial class RaycastSweep : Node3D, IDisposable
     {

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -72,8 +72,6 @@ namespace Jumpvalley.Raycasting
         /// <param name="endPosition"></param>
         public RaycastSweep(int numRaycasts, Vector3 startPosition, Vector3 endPosition, float raycastLength)
         {
-            if (numRaycasts < 2) throw new ArgumentOutOfRangeException("numRaycasts", "RaycastSweep requires that there are at least 2 raycasts to work with.");
-
             Name = $"{nameof(RaycastSweep)}_{GetHashCode()}";
 
             NumRaycasts = numRaycasts;
@@ -92,6 +90,9 @@ namespace Jumpvalley.Raycasting
         public void UpdateRaycastLayout()
         {
             int numRaycasts = NumRaycasts;
+
+            if (numRaycasts < 2) throw new ArgumentOutOfRangeException("numRaycasts", "RaycastSweep requires that there are at least 2 raycasts to work with.");
+
             float raycastLength = RaycastLength;
             Vector3 startPosition = StartPosition;
             Vector3 endPosition = EndPosition;
@@ -161,7 +162,7 @@ namespace Jumpvalley.Raycasting
         /// Gets the current collision info for the specified raycast.
         /// </summary>
         /// <param name="r">The raycast to use</param>
-        /// <param name="raycastIndex">The numeric index of the raycast in the <see cref="RaycastSweep.Raycasts"/> list it belongs to</param>
+        /// <param name="raycastIndex">The numeric index of the raycast in the <see cref="Raycasts"/> list it belongs to</param>
         /// <returns></returns>
         private static RaycastSweepResult GetCurrentRaycastCollisionInfo(RayCast3D r, int raycastIndex)
         {

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Godot;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,5 +12,24 @@ namespace Jumpvalley.Raycasting
     /// </summary>
     public partial class RaycastSweep
     {
+        /// <summary>
+        /// The total number of raycasts that the raycast sweep will perform from the start position to the end position.
+        /// </summary>
+        public int NumRaycasts { get; private set; }
+
+        /// <summary>
+        /// The starting position of the raycast sweep. This is where the first raycast will begin.
+        /// </summary>
+        public Vector3 StartPosition { get; private set; }
+
+        /// <summary>
+        /// The ending position of the raycast sweep. This is where the last raycast will begin.
+        /// </summary>
+        public Vector3 EndPosition { get; private set; }
+
+        public RaycastSweep()
+        {
+
+        }
     }
 }

--- a/src/main/Raycasting/RaycastSweep.cs
+++ b/src/main/Raycasting/RaycastSweep.cs
@@ -84,6 +84,8 @@ namespace Jumpvalley.Raycasting
 
         /// <summary>
         /// Runs through the raycasts in <see cref="Raycasts"/> from left-to-right.
+        /// <br/>
+        /// <br/>
         /// This returns raycast collision information about the first raycast in <see cref="Raycasts"/>
         /// that got collided with. If no raycast in <see cref="Raycasts"/> was hit,
         /// this function returns null.

--- a/src/main/Raycasting/RaycastSweepResult.cs
+++ b/src/main/Raycasting/RaycastSweepResult.cs
@@ -6,7 +6,7 @@ namespace Jumpvalley.Raycasting
     /// Class that contains data about the result of a raycast sweep operation
     /// (where collisions with a <see cref="RaycastSweep"/>'s raycasts are checked).
     /// </summary>
-    public partial class RaycastSweepResults
+    public partial class RaycastSweepResult
     {
         /// <summary>
         /// The raycast that got collided with.
@@ -23,7 +23,7 @@ namespace Jumpvalley.Raycasting
         /// </summary>
         public Node3D CollidedObject;
 
-        public RaycastSweepResults(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject)
+        public RaycastSweepResult(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject)
         {
             Raycast = raycast;
             CollisionPoint = collisionPoint;

--- a/src/main/Raycasting/RaycastSweepResult.cs
+++ b/src/main/Raycasting/RaycastSweepResult.cs
@@ -19,9 +19,9 @@ namespace Jumpvalley.Raycasting
         public Vector3 CollisionPoint;
 
         /// <summary>
-        /// The <see cref="Node3D"/> that the raycast hit.
+        /// The <see cref="GodotObject"/> that the raycast hit.
         /// </summary>
-        public Node3D CollidedObject;
+        public GodotObject CollidedObject;
 
         /// <summary>
         /// The numeric index of the raycast that got collided with.
@@ -29,7 +29,7 @@ namespace Jumpvalley.Raycasting
         /// </summary>
         public int RaycastIndex;
 
-        public RaycastSweepResult(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject, int raycastIndex)
+        public RaycastSweepResult(RayCast3D raycast, Vector3 collisionPoint, GodotObject collidedObject, int raycastIndex)
         {
             Raycast = raycast;
             CollisionPoint = collisionPoint;

--- a/src/main/Raycasting/RaycastSweepResult.cs
+++ b/src/main/Raycasting/RaycastSweepResult.cs
@@ -23,11 +23,18 @@ namespace Jumpvalley.Raycasting
         /// </summary>
         public Node3D CollidedObject;
 
-        public RaycastSweepResult(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject)
+        /// <summary>
+        /// The numeric index of the raycast that got collided with.
+        /// This index should be equal to the index in <see cref="RaycastSweep.Raycasts"/> where this raycast is stored.
+        /// </summary>
+        public int RaycastIndex;
+
+        public RaycastSweepResult(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject, int raycastIndex)
         {
             Raycast = raycast;
             CollisionPoint = collisionPoint;
             CollidedObject = collidedObject;
+            RaycastIndex = raycastIndex;
         }
     }
 }

--- a/src/main/Raycasting/RaycastSweepResults.cs
+++ b/src/main/Raycasting/RaycastSweepResults.cs
@@ -1,0 +1,33 @@
+﻿using Godot;
+
+namespace Jumpvalley.Raycasting
+{
+    /// <summary>
+    /// Class that contains data about the result of a raycast sweep operation
+    /// (where collisions with a <see cref="RaycastSweep"/>'s raycasts are checked).
+    /// </summary>
+    public partial class RaycastSweepResults
+    {
+        /// <summary>
+        /// The raycast that got collided with.
+        /// </summary>
+        public RayCast3D Raycast;
+
+        /// <summary>
+        /// The global-space position where the raycast hit an object.
+        /// </summary>
+        public Vector3 CollisionPoint;
+
+        /// <summary>
+        /// The <see cref="Node3D"/> that the raycast hit.
+        /// </summary>
+        public Node3D CollidedObject;
+
+        public RaycastSweepResults(RayCast3D raycast, Vector3 collisionPoint, Node3D collidedObject)
+        {
+            Raycast = raycast;
+            CollisionPoint = collisionPoint;
+            CollidedObject = collidedObject;
+        }
+    }
+}

--- a/src/main/Testing/RaycastSweepTest.cs
+++ b/src/main/Testing/RaycastSweepTest.cs
@@ -1,0 +1,51 @@
+﻿using Godot;
+using System;
+
+using Jumpvalley.Raycasting;
+
+namespace Jumpvalley.Testing
+{
+    /// <summary>
+    /// Test class for making sure the <see cref="RaycastSweep"/> class works properly
+    /// </summary>
+    public partial class RaycastSweepTest: Node
+    {
+        public RaycastSweep TestRaycastSweep;
+        public Label RaycastResultLabel;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="RaycastSweepTest"/>
+        /// </summary>
+        /// <param name="raycastSweep">The raycast sweep to apply</param>
+        /// <param name="node">The Node3D to use the raycast sweep for</param>
+        public RaycastSweepTest(RaycastSweep raycastSweep, Node3D node)
+        {
+            if (node == null) throw new ArgumentNullException("node");
+
+            RaycastResultLabel = new Label();
+
+            TestRaycastSweep = raycastSweep;
+            node.AddChild(raycastSweep);
+        }
+
+        public override void _PhysicsProcess(double delta)
+        {
+            base._PhysicsProcess(delta);
+
+            RaycastSweepResult results = TestRaycastSweep.PerformRaycast();
+
+            string resultText = $"RaycastSweep results for {RaycastResultLabel.Name}\n";
+            
+            if (results == null)
+            {
+                resultText += "Currently not colliding with anything";
+            }
+            else
+            {
+                resultText += $"Collided object: {results.CollidedObject}\nCollision point: {results.CollisionPoint}\nColliding raycast: {results.Raycast}\nColliding raycast index: {results.RaycastIndex}";
+            }
+
+            RaycastResultLabel.Text = resultText;
+        }
+    }
+}

--- a/src/main/Testing/RaycastSweepTest.cs
+++ b/src/main/Testing/RaycastSweepTest.cs
@@ -20,7 +20,10 @@ namespace Jumpvalley.Testing
         /// <param name="node">The Node3D to use the raycast sweep for</param>
         public RaycastSweepTest(RaycastSweep raycastSweep, Node3D node)
         {
+            Name = $"{nameof(RaycastSweepTest)}_{GetHashCode()}";
+
             RaycastResultLabel = new Label();
+            RaycastResultLabel.Name = $"RaycastSweepResultLabel_{GetHashCode()}";
 
             TestRaycastSweep = raycastSweep;
             node?.AddChild(raycastSweep);
@@ -32,7 +35,7 @@ namespace Jumpvalley.Testing
 
             RaycastSweepResult results = TestRaycastSweep.PerformRaycast();
 
-            string resultText = $"RaycastSweep results for {RaycastResultLabel.Name}\n";
+            string resultText = $"RaycastSweep results for {TestRaycastSweep.Name}\n";
             
             if (results == null)
             {

--- a/src/main/Testing/RaycastSweepTest.cs
+++ b/src/main/Testing/RaycastSweepTest.cs
@@ -20,12 +20,10 @@ namespace Jumpvalley.Testing
         /// <param name="node">The Node3D to use the raycast sweep for</param>
         public RaycastSweepTest(RaycastSweep raycastSweep, Node3D node)
         {
-            if (node == null) throw new ArgumentNullException("node");
-
             RaycastResultLabel = new Label();
 
             TestRaycastSweep = raycastSweep;
-            node.AddChild(raycastSweep);
+            node?.AddChild(raycastSweep);
         }
 
         public override void _PhysicsProcess(double delta)

--- a/src/main/Testing/RaycastSweepTest.cs
+++ b/src/main/Testing/RaycastSweepTest.cs
@@ -35,7 +35,7 @@ namespace Jumpvalley.Testing
         {
             base._PhysicsProcess(delta);
 
-            RaycastSweepResult results = TestRaycastSweep.PerformRaycast(SweepOrder);
+            RaycastSweepResult results = TestRaycastSweep.PerformSweep(SweepOrder);
 
             string resultText = $"RaycastSweep results for {TestRaycastSweep.Name}\n";
             

--- a/src/main/Testing/RaycastSweepTest.cs
+++ b/src/main/Testing/RaycastSweepTest.cs
@@ -12,13 +12,14 @@ namespace Jumpvalley.Testing
     {
         public RaycastSweep TestRaycastSweep;
         public Label RaycastResultLabel;
+        public RaycastSweep.SweepOrder SweepOrder;
 
         /// <summary>
         /// Creates a new instance of <see cref="RaycastSweepTest"/>
         /// </summary>
         /// <param name="raycastSweep">The raycast sweep to apply</param>
         /// <param name="node">The Node3D to use the raycast sweep for</param>
-        public RaycastSweepTest(RaycastSweep raycastSweep, Node3D node)
+        public RaycastSweepTest(RaycastSweep raycastSweep, Node3D node, RaycastSweep.SweepOrder sweepOrder)
         {
             Name = $"{nameof(RaycastSweepTest)}_{GetHashCode()}";
 
@@ -26,6 +27,7 @@ namespace Jumpvalley.Testing
             RaycastResultLabel.Name = $"RaycastSweepResultLabel_{GetHashCode()}";
 
             TestRaycastSweep = raycastSweep;
+            SweepOrder = sweepOrder;
             node?.AddChild(raycastSweep);
         }
 
@@ -33,7 +35,7 @@ namespace Jumpvalley.Testing
         {
             base._PhysicsProcess(delta);
 
-            RaycastSweepResult results = TestRaycastSweep.PerformRaycast();
+            RaycastSweepResult results = TestRaycastSweep.PerformRaycast(SweepOrder);
 
             string resultText = $"RaycastSweep results for {TestRaycastSweep.Name}\n";
             


### PR DESCRIPTION
Fixes #8

This took way too long. But finally, a lot of the problems with climbing have been fixed as a result of this pull request.

- Climbing up and down now works properly
- You can now turn your character while rapid-climbing, even while you have shift-lock off.
- You can now climb an object at a wider range of angles (relative to the climbable object's face that you're currently climbing). It should now more closely mimic Juke's Towers of Hell.

In addition, Jumpvalley's new RaycastSweep API was made along the way to help make these fixes.