### PR TITLE
Remove PCK loader from the game's code

### DIFF
--- a/levels/demo_platformer/info.txt
+++ b/levels/demo_platformer/info.txt
@@ -3,4 +3,3 @@ full_name: Demo Platformer
 creators: UTheDev
 difficulty: 5.03
 scene_path: level.tscn
-resource_pack_path: level.pck

--- a/levels/shape_variety/info.txt
+++ b/levels/shape_variety/info.txt
@@ -3,4 +3,3 @@ full_name: Shape Variety Demo
 creators: UTheDev
 difficulty: 6.54
 scene_path: level.tscn
-resource_pack_path: level.pck

--- a/scenes/lobby/info.txt
+++ b/scenes/lobby/info.txt
@@ -3,4 +3,3 @@ full_name: Lobby
 creators: UTheDev
 difficulty: 0.00
 scene_path: level.tscn
-resource_pack_path: level.pck

--- a/src/main/Levels/LevelInfoFile.cs
+++ b/src/main/Levels/LevelInfoFile.cs
@@ -5,7 +5,7 @@ namespace Jumpvalley.Levels
     /// <summary>
     /// Reads an info file for a Jumpvalley level
     /// </summary>
-    public partial class LevelInfoFile: IO.InfoFile
+    public partial class LevelInfoFile : IO.InfoFile
     {
         /// <summary>
         /// The level's internal identifier. For example, you can make the identifier a shortened version of the full name.
@@ -37,18 +37,12 @@ namespace Jumpvalley.Levels
         /// </summary>
         public string ScenePath;
 
-        /// <summary>
-        /// The file path to the Godot package (PCK file) that contains the level's contents, including the file name and extension. This path should typically be relative to the level's root folder.
-        /// </summary>
-        public string ResourcePackPath;
-
-        public LevelInfoFile(string text): base(text)
+        public LevelInfoFile(string text) : base(text)
         {
             Data.TryGetValue("id", out Id);
             Data.TryGetValue("full_name", out FullName);
             Data.TryGetValue("creators", out Creators);
             Data.TryGetValue("scene_path", out ScenePath);
-            Data.TryGetValue("resource_pack_path", out ResourcePackPath);
 
             string difficultyText;
 

--- a/src/main/Levels/LevelPackage.cs
+++ b/src/main/Levels/LevelPackage.cs
@@ -16,27 +16,6 @@ namespace Jumpvalley.Levels
     public partial class LevelPackage : IDisposable
     {
         /// <summary>
-        /// Status codes that indicate the result of an attempt to load a level's resource pack
-        /// </summary>
-        public enum ResourcePackLoadStatus
-        {
-            /// <summary>
-            /// Indicates that the Godot package was loaded successfully.
-            /// </summary>
-            Success = 0,
-
-            /// <summary>
-            /// Indicates that the Godot package under the given file name could not be found.
-            /// </summary>
-            FileNotFound = 1,
-
-            /// <summary>
-            /// Indicates that the Godot package under the given file name was found, but loading it failed.
-            /// </summary>
-            LoadingFailed = 2
-        }
-
-        /// <summary>
         /// The level's info file
         /// </summary>
         public LevelInfoFile Info { get; private set; }
@@ -78,29 +57,6 @@ namespace Jumpvalley.Levels
 
             Info = new LevelInfoFile(infoFile.GetAsText());
             Runner = runner;
-        }
-
-        /// <summary>
-        /// Attempts to load the resource pack specified within the level's info file if it exists
-        /// </summary>
-        /// <returns>
-        /// A status code indicating the results of the attempt to load the resource pack
-        /// </returns>
-        public ResourcePackLoadStatus TryLoadResourcePack()
-        {
-            string resourcePackPath = $"{Path}/{Info.ResourcePackPath}";
-            if (!FileAccess.FileExists(resourcePackPath))
-            {
-                return ResourcePackLoadStatus.FileNotFound;
-            }
-
-            // LoadResourcePack will also only return true if the loading of the resource pack succeeded
-            if (ProjectSettings.LoadResourcePack(resourcePackPath, false))
-            {
-                return ResourcePackLoadStatus.Success;
-            }
-
-            return ResourcePackLoadStatus.LoadingFailed;
         }
 
         /// <summary>

--- a/src/main/Testing/LevelLoadingTest.cs
+++ b/src/main/Testing/LevelLoadingTest.cs
@@ -9,7 +9,7 @@ namespace Jumpvalley.Testing
     /// <summary>
     /// Testing of the level loading prototype
     /// </summary>
-    public partial class LevelLoadingTest: BaseTest, IDisposable
+    public partial class LevelLoadingTest : BaseTest, IDisposable
     {
         public string LevelDirPath;
         public LevelPackage Package;
@@ -69,7 +69,6 @@ namespace Jumpvalley.Testing
 
             LevelRunner levelRunner = new LevelRunner(CurrentPlayer);
             Package = new LevelPackage(LevelDirPath, levelRunner);
-            Package.TryLoadResourcePack();
             Package.LoadRootNode();
             Package.CreateLevelInstance();
 


### PR DESCRIPTION
As a security precaution, this pull request removes the PCK loader function from the `LevelPackage` class.

These were also removed:

- Related code
- usages of the function
- `resource_pack_path` properties from info files belonging to levels in the game