### PR TITLE
Have MusicZonePlayer only update CurrentPlaylist once per frame

### DIFF
--- a/src/main/Music/MusicZonePlayer.cs
+++ b/src/main/Music/MusicZonePlayer.cs
@@ -12,6 +12,10 @@ namespace Jumpvalley.Music
     /// <br/>
     /// In order for music to play when the player is outside a music zone, a primary playlist must be set.
     /// This playlist will get played when outside of the music zones.
+    /// <br/>
+    /// <br/>
+    /// It's important to note that MusicZonePlayer will only update <see cref="CurrentPlaylist"/> once per process frame for stability reasons
+    /// (as long as the calling of MusicZonePlayer's _Process() function hasn't been disabled).
     /// </summary>
     public partial class MusicZonePlayer : MusicPlayer, IDisposable
     {
@@ -38,7 +42,6 @@ namespace Jumpvalley.Music
 
         /// <summary>
         /// Deregisters a music zone from playback.
-        /// If the removed music zone is equal to <see cref="CurrentPlaylist"/> and <see cref="IsPlaying"/> is true, <see cref="CurrentPlaylist"/> will be set to <see cref="PrimaryPlaylist"/>.
         /// </summary>
         /// <param name="zone"></param>
         public void Remove(MusicZone zone)
@@ -46,11 +49,6 @@ namespace Jumpvalley.Music
             if (zone != null)
             {
                 Zones.Remove(zone);
-
-                if (IsPlaying && CurrentPlaylist != zone)
-                {
-                    CurrentPlaylist = PrimaryPlaylist;
-                }
             }
         }
 

--- a/src/main/Music/MusicZonePlayer.cs
+++ b/src/main/Music/MusicZonePlayer.cs
@@ -47,7 +47,7 @@ namespace Jumpvalley.Music
             {
                 Zones.Remove(zone);
 
-                if (IsPlaying && CurrentPlaylist == zone)
+                if (IsPlaying && CurrentPlaylist != zone)
                 {
                     CurrentPlaylist = PrimaryPlaylist;
                 }


### PR DESCRIPTION
This was done for stability reasons (e.g. if we get to a situation where we switch music zones multiple times in one frame, we only want to play the final music zone we switched to).

This PR also fixes #20.