### PR TITLE
Tweak acceleration

### DIFF
--- a/src/Game/JumpvalleyPlayer.cs
+++ b/src/Game/JumpvalleyPlayer.cs
@@ -58,7 +58,7 @@ namespace Jumpvalley.Game
             Mover.Gravity = PhysicsServer3D.AreaGetParam(RootNode.GetViewport().FindWorld3D().Space, PhysicsServer3D.AreaParameter.Gravity).As<float>();
             Mover.JumpVelocity = 25f;
             Mover.Speed = 8f;
-            Mover.Acceleration = 144f;
+            Mover.Acceleration = 180f;
 
             Mover.Body = Character;
 

--- a/src/Game/Testing/AccelerationTest.cs
+++ b/src/Game/Testing/AccelerationTest.cs
@@ -16,6 +16,7 @@ namespace Jumpvalley.Game.Testing
             mover = moverToTest;
 
             label = new Label();
+            AddChild(label);
         }
 
         public override void _Process(double delta)

--- a/src/Game/Testing/AccelerationTest.cs
+++ b/src/Game/Testing/AccelerationTest.cs
@@ -28,7 +28,7 @@ namespace Jumpvalley.Game.Testing
             }
             else
             {
-                label.Text = $"Testing acceleration handled by {mover.Name}\nAcceleration: {mover.Acceleration} m/s^2\nVelocity: {body}\nReal velocity: {body.GetRealVelocity()}";
+                label.Text = $"Testing acceleration handled by {mover.Name}\nAcceleration: {mover.Acceleration} m/s^2\nVelocity: {body.Velocity}\nReal velocity: {body.GetRealVelocity()}";
             }
 
             base._Process(delta);

--- a/src/Game/Testing/AccelerationTest.cs
+++ b/src/Game/Testing/AccelerationTest.cs
@@ -20,7 +20,15 @@ namespace Jumpvalley.Game.Testing
 
         public override void _Process(double delta)
         {
-            label.Text = $"";
+            CharacterBody3D body = mover.Body;
+            if (body == null)
+            {
+                label.Text = "BaseMover we're currently testing has no CharacterBody3D assigned to it";
+            }
+            else
+            {
+                label.Text = $"Testing acceleration handled by {mover.Name}\nVelocity: {body}\nReal velocity: {body.GetRealVelocity()}";
+            }
 
             base._Process(delta);
         }

--- a/src/Game/Testing/AccelerationTest.cs
+++ b/src/Game/Testing/AccelerationTest.cs
@@ -1,0 +1,28 @@
+using Godot;
+using Jumpvalley.Players.Movement;
+
+namespace Jumpvalley.Game.Testing
+{
+    /// <summary>
+    /// Tests how BaseMover acceleration calculations affect the velocity of the character it's assigned to.
+    /// </summary>
+    public partial class AccelerationTest : Node
+    {
+        private BaseMover mover;
+        private Label label;
+
+        public AccelerationTest(BaseMover moverToTest)
+        {
+            mover = moverToTest;
+
+            label = new Label();
+        }
+
+        public override void _Process(double delta)
+        {
+            label.Text = $"";
+
+            base._Process(delta);
+        }
+    }
+}

--- a/src/Game/Testing/AccelerationTest.cs
+++ b/src/Game/Testing/AccelerationTest.cs
@@ -27,7 +27,7 @@ namespace Jumpvalley.Game.Testing
             }
             else
             {
-                label.Text = $"Testing acceleration handled by {mover.Name}\nVelocity: {body}\nReal velocity: {body.GetRealVelocity()}";
+                label.Text = $"Testing acceleration handled by {mover.Name}\nAcceleration: {mover.Acceleration} m/s^2\nVelocity: {body}\nReal velocity: {body.GetRealVelocity()}";
             }
 
             base._Process(delta);


### PR DESCRIPTION
This increases the character's default acceleration in Jumpvalley from 144 m/s<sup>2</sup> to 180 m/s<sup>2</sup>. The main reason for this change is to make sharp and fast changes in direction easier, while maintaining smooth velocity changes when jumping off a conveyor.

This PR also adds a test class for testing how `BaseMover`'s implementation of acceleration affects velocity in Jumpvalley.