### PR TITLE
Make climbing logic use a ShapeCast3D

### DIFF
--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -271,47 +271,39 @@ metadata/is_climbable = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
 shape = SubResource("BoxShape3D_um7wl")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.75, 0)
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.75, 0)
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.75, 0)
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.25, 0)
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.25, 0)
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
-[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.25, 0)
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../..")
 
 [node name="LadderFlickTest" type="Node3D" parent="StaticObjects"]
 

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -271,43 +271,43 @@ metadata/is_climbable = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
 shape = SubResource("BoxShape3D_um7wl")
 
-[node name="ClimbablePartDisplay" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.75, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay2" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.75, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay3" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.75, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay4" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay5" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.25, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay6" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.25, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 skeleton = NodePath("../../../..")
 
-[node name="ClimbablePartDisplay7" type="MeshInstance3D" parent="StaticObjects/Ladder"]
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/Ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.25, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -305,6 +305,86 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
 material_override = SubResource("StandardMaterial3D_pea2e")
 mesh = SubResource("BoxMesh_m1ep8")
 
+[node name="MultiPartLadder" type="StaticBody3D" parent="StaticObjects"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 19, 3.5, -32)
+metadata/is_climbable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticObjects/MultiPartLadder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+shape = SubResource("BoxShape3D_um7wl")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="CollisionShape3D2" type="CollisionShape3D" parent="StaticObjects/MultiPartLadder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9, 0.25, -3)
+shape = SubResource("BoxShape3D_um7wl")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/MultiPartLadder/CollisionShape3D2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
 [node name="LadderFlickTest" type="Node3D" parent="StaticObjects"]
 
 [node name="Top" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest"]

--- a/scenes/lobby/level.tscn
+++ b/scenes/lobby/level.tscn
@@ -307,56 +307,6 @@ mesh = SubResource("BoxMesh_m1ep8")
 
 [node name="LadderFlickTest" type="Node3D" parent="StaticObjects"]
 
-[node name="Ladder" type="StaticBody3D" parent="StaticObjects/LadderFlickTest"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 3.5, -20.5)
-metadata/is_climbable = true
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
-shape = SubResource("BoxShape3D_um7wl")
-
-[node name="ClimbablePartDisplay" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.75, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay2" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.75, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay3" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.75, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay4" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay5" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.25, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay6" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.25, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
-[node name="ClimbablePartDisplay7" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.25, 0)
-material_override = SubResource("StandardMaterial3D_pea2e")
-mesh = SubResource("BoxMesh_m1ep8")
-skeleton = NodePath("../../../../..")
-
 [node name="Top" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 11.5, -20.5)
 material_override = SubResource("StandardMaterial3D_pea2e")
@@ -367,6 +317,48 @@ skeleton = NodePath("../../../..")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="StaticObjects/LadderFlickTest/Top/StaticBody3D"]
 shape = SubResource("BoxShape3D_5ddbb")
+
+[node name="Ladder" type="StaticBody3D" parent="StaticObjects/LadderFlickTest"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.5, 3.5, -20.5)
+metadata/is_climbable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticObjects/LadderFlickTest/Ladder"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+shape = SubResource("BoxShape3D_um7wl")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="StaticObjects/LadderFlickTest/Ladder/CollisionShape3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+material_override = SubResource("StandardMaterial3D_pea2e")
+mesh = SubResource("BoxMesh_m1ep8")
 
 [node name="CylindricalLadder" type="Node3D" parent="StaticObjects"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 1.5, -15.5)

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -432,7 +432,7 @@ namespace Jumpvalley.Players.Movement
 
                     // Determine the 3d object's normal that we're climbing on
                     // Because the object can have curvy surfaces,
-                    // and because the RaycastSweep can hit multiple objects at once,
+                    // and because the shape-cast can hit multiple objects at once,
                     // we want to use the raycast that "travelled" the smallest distance
                     // as the raycast we're working with.
                     int collisionCount = climbingShapeCast.GetCollisionCount();

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -322,7 +322,7 @@ namespace Jumpvalley.Players.Movement
 
             // For performance reasons
             climbingShapeCast.Enabled = false;
-            
+
             float hitboxDepth = CurrentClimber.HitboxDepth;
             climbingShapeCast.TargetPosition = new Vector3(0f, 0f, hitboxDepth);
 
@@ -422,14 +422,18 @@ namespace Jumpvalley.Players.Movement
                     // Update climbing shape-cast's state
                     climbingShapeCast.ForceShapecastUpdate();
 
-
                     // Determine the 3d object's normal that we're climbing on
                     // Because the object can have curvy surfaces,
                     // and because the RaycastSweep can hit multiple objects at once,
                     // we want to use the raycast that "travelled" the smallest distance
                     // as the raycast we're working with.
+                    int collisionCount = climbingShapeCast.GetCollisionCount();
+                    float shortestDistance = -1;
                     RayCast3D selectedRaycast = null;
-                    
+                    for (int i = 0; i < collisionCount; i++)
+                    {
+                        
+                    }
 
                     if (selectedRaycast != null)
                     {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -240,15 +240,17 @@ namespace Jumpvalley.Players.Movement
 
                         // For simplification
                         //float xPos = climberHitboxWidth / 2;
-                        
+
                         float zPos = -(boxShape.Size.Z / 2) + CLIMBING_SHAPE_CAST_Z_OFFSET;
 
                         BoxShape3D shapeCastBox = climbingShapeCast.Shape as BoxShape3D;
                         if (shapeCastBox != null)
                         {
-                            // Height of the climbing shape-cast should be half the height of the character
+                            // Height of the climbing shape-cast should be half the height of the character.
+                            // 1 additional meter is added to the shape-cast's height to prevent the character from
+                            // getting stuck while climbing when at the very top or bottom of a ladder
                             Vector3 size = shapeCastBox.Size;
-                            size.Y = boxShape.Size.Y * 0.5f;
+                            size.Y = (boxShape.Size.Y * 0.5f) + 1f;
                             shapeCastBox.Size = size;
 
                             climbingShapeCast.Position = new Vector3(0, -boxShape.Size.Y * 0.25f, zPos);

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -261,6 +261,16 @@ namespace Jumpvalley.Players.Movement
 
                         // The position of the climbing raycast sweep should be based on the position of the character
                         value.AddChild(climbingRaycastSweep);
+
+                        BoxShape3D shapeCastBox = climbingShapeCast.Shape as BoxShape3D;
+                        if (shapeCastBox != null)
+                        {
+                            // Height of the climbing shape cast should be half the height of the character
+                            Vector3 size = shapeCastBox.Size;
+                            size.Y = boxShape.Size.Y * 0.5f;
+                            shapeCastBox.Size = size;
+                            value.AddChild(climbingShapeCast);
+                        }
                     }
                 }
             }
@@ -336,8 +346,14 @@ namespace Jumpvalley.Players.Movement
             LastVelocity = Vector3.Zero;
 
             climbingRaycastSweep = new RaycastSweep(5, Vector3.Zero, Vector3.Zero, -1f);
+
             climbingShapeCast = new ShapeCast3D();
-            climbingShapeCast.Shape = new BoxShape3D();
+            float hitboxDepth = CurrentClimber.HitboxDepth;
+            climbingShapeCast.TargetPosition = new Vector3(0f, 0f, hitboxDepth);
+
+            BoxShape3D shapeCastBox = new BoxShape3D();
+            shapeCastBox.Size = new Vector3(CurrentClimber.HitboxWidth, 0f, hitboxDepth);
+            climbingShapeCast.Shape = shapeCastBox;
 
             AddChild(CurrentClimber);
 
@@ -456,7 +472,6 @@ namespace Jumpvalley.Players.Movement
                             }
                         }
                     }
-
                     
 
                     if (selectedRaycast != null)

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -310,6 +310,11 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         private RaycastSweep climbingRaycastSweep;
 
+        /// <summary>
+        /// Shape-cast used to grab the normal of an object that the player is climbing on
+        /// </summary>
+        private ShapeCast3D climbingShapeCast;
+
         //private ConsoleLogger logger;
 
         /// <summary>
@@ -331,6 +336,8 @@ namespace Jumpvalley.Players.Movement
             LastVelocity = Vector3.Zero;
 
             climbingRaycastSweep = new RaycastSweep(5, Vector3.Zero, Vector3.Zero, -1f);
+            climbingShapeCast = new ShapeCast3D();
+            climbingShapeCast.Shape = new BoxShape3D();
 
             AddChild(CurrentClimber);
 
@@ -449,6 +456,8 @@ namespace Jumpvalley.Players.Movement
                             }
                         }
                     }
+
+                    
 
                     if (selectedRaycast != null)
                     {

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -306,7 +306,7 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         private ShapeCast3D climbingShapeCast;
 
-        private ConsoleLogger logger;
+        //private ConsoleLogger logger;
 
         /// <summary>
         /// Constructs a new instance of BaseMover that can be used to handle character movement
@@ -340,7 +340,7 @@ namespace Jumpvalley.Players.Movement
 
             AddChild(CurrentClimber);
 
-            logger = new ConsoleLogger(nameof(BaseMover));
+            //logger = new ConsoleLogger(nameof(BaseMover));
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace Jumpvalley.Players.Movement
                     int collisionCount = climbingShapeCast.GetCollisionCount();
                     float shortestDistance = -1f;
                     Vector3 climbingNormal = Vector3.Zero; // Ladder collision normal
-                    logger.Print($"climbingShapeCast reported {collisionCount} collisions");
+                    //logger.Print($"climbingShapeCast reported {collisionCount} collisions");
                     for (int i = 0; i < collisionCount; i++)
                     {
                         if (Climber.IsClimbable(climbingShapeCast.GetCollider(i)))

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -246,7 +246,7 @@ namespace Jumpvalley.Players.Movement
                             Vector3 size = shapeCastBox.Size;
                             size.Y = boxShape.Size.Y * 0.5f;
                             shapeCastBox.Size = size;
-                            
+
                             value.AddChild(climbingShapeCast);
                         }
                     }
@@ -319,6 +319,10 @@ namespace Jumpvalley.Players.Movement
             LastVelocity = Vector3.Zero;
 
             climbingShapeCast = new ShapeCast3D();
+
+            // For performance reasons
+            climbingShapeCast.Enabled = false;
+            
             float hitboxDepth = CurrentClimber.HitboxDepth;
             climbingShapeCast.TargetPosition = new Vector3(0f, 0f, hitboxDepth);
 
@@ -415,10 +419,9 @@ namespace Jumpvalley.Players.Movement
                 }
                 else
                 {
-                    // Move raycast sweep's raycasts to have a y-position equal to the y-position of the object currently being climbed,
-                    // to make sure at least one of the raycasts hit the object being climbed.
-                    // We'll also need to change their x and z positions too.
-                    Vector3 climbedObjectPos = CurrentClimber.CurrentlyClimbedObject.GlobalPosition;
+                    // Update climbing shape-cast's state
+                    climbingShapeCast.ForceShapecastUpdate();
+
 
                     // Determine the 3d object's normal that we're climbing on
                     // Because the object can have curvy surfaces,

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -666,8 +666,8 @@ namespace Jumpvalley.Players.Movement
                 // changed as a result of applying acceleration for this frame.
                 Vector2 newXZVelocityDiff = new Vector2(moveVelocity.X, moveVelocity.Z) - new Vector2(finalVelocity.X, finalVelocity.Z);
                 //logger.Print($"Velocity angle diff: {newXZVelocityDiff.Normalized().Angle() - direction.Angle()}");
-                if (!Mathf.IsZeroApprox(newXZVelocityDiff.Normalized().Angle() - direction.Angle())
-                || newXZVelocityDiff.Length() <= VELOCITY_DIFF_SNAP_THRESHOLD
+                if (newXZVelocityDiff.Length() <= VELOCITY_DIFF_SNAP_THRESHOLD
+                || Mathf.IsZeroApprox(newXZVelocityDiff.Normalized().Angle() - direction.Angle()) == false
                 )
                 {
                     finalVelocity = moveVelocity;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -68,6 +68,12 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         private static readonly float VELOCITY_DIFF_SNAP_THRESHOLD = 0.1f;
 
+        /// <summary>
+        /// For preventing cases where being too close to a climbable object
+        /// will cause the climbing shape-cast to not be able to hit the outer surface of the climbable object.
+        /// </summary>
+        private static readonly float CLIMBING_SHAPE_CAST_Z_OFFSET = 0.005f;
+
         private BodyState _currentBodyState = BodyState.Stopped;
 
         /// <summary>
@@ -234,10 +240,8 @@ namespace Jumpvalley.Players.Movement
 
                         // For simplification
                         //float xPos = climberHitboxWidth / 2;
-
-                        // Offset by 0.005 meters into the character hitbox to prevent cases where being too close to a climbable object
-                        // will cause the raycast sweep's raycasts to not be able to hit the outer surface of the climbable object.
-                        float zPos = -(boxShape.Size.Z / 2) + 0.005f;
+                        
+                        float zPos = -(boxShape.Size.Z / 2) + CLIMBING_SHAPE_CAST_Z_OFFSET;
 
                         BoxShape3D shapeCastBox = climbingShapeCast.Shape as BoxShape3D;
                         if (shapeCastBox != null)
@@ -247,7 +251,7 @@ namespace Jumpvalley.Players.Movement
                             size.Y = boxShape.Size.Y * 0.5f;
                             shapeCastBox.Size = size;
 
-                            climbingShapeCast.Position = new Vector3(0, 0, zPos);
+                            climbingShapeCast.Position = new Vector3(0, -boxShape.Size.Y * 0.25f, zPos);
 
                             value.AddChild(climbingShapeCast);
                         }
@@ -326,10 +330,10 @@ namespace Jumpvalley.Players.Movement
             climbingShapeCast.Enabled = false;
 
             float hitboxDepth = CurrentClimber.HitboxDepth;
-            climbingShapeCast.TargetPosition = new Vector3(0f, 0f, -hitboxDepth);
+            climbingShapeCast.TargetPosition = new Vector3(0f, 0f, -hitboxDepth - CLIMBING_SHAPE_CAST_Z_OFFSET);
 
             BoxShape3D shapeCastBox = new BoxShape3D();
-            shapeCastBox.Size = new Vector3(CurrentClimber.HitboxWidth, 0f, hitboxDepth);
+            shapeCastBox.Size = new Vector3(CurrentClimber.HitboxWidth, 0f, hitboxDepth + CLIMBING_SHAPE_CAST_Z_OFFSET);
             climbingShapeCast.Shape = shapeCastBox;
 
             AddChild(CurrentClimber);

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -653,7 +653,7 @@ namespace Jumpvalley.Players.Movement
                 )
                 {
                     finalVelocity = moveVelocity;
-                    logger.Print("Snapped velocity");
+                    //logger.Print("Snapped velocity");
                 }
 
                 body.Velocity = finalVelocity;

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -229,11 +229,11 @@ namespace Jumpvalley.Players.Movement
 
                     if (boxShape != null)
                     {
-                        float climberHitboxWidth = climber.HitboxWidth;
-                        float climberHitboxDepth = climber.HitboxDepth;
+                        //float climberHitboxWidth = climber.HitboxWidth;
+                        //float climberHitboxDepth = climber.HitboxDepth;
 
                         // For simplification
-                        float xPos = climberHitboxWidth / 2;
+                        //float xPos = climberHitboxWidth / 2;
 
                         // Offset by 0.005 meters into the character hitbox to prevent cases where being too close to a climbable object
                         // will cause the raycast sweep's raycasts to not be able to hit the outer surface of the climbable object.
@@ -246,6 +246,8 @@ namespace Jumpvalley.Players.Movement
                             Vector3 size = shapeCastBox.Size;
                             size.Y = boxShape.Size.Y * 0.5f;
                             shapeCastBox.Size = size;
+
+                            climbingShapeCast.Position = new Vector3(0, 0, zPos);
 
                             value.AddChild(climbingShapeCast);
                         }
@@ -324,7 +326,7 @@ namespace Jumpvalley.Players.Movement
             climbingShapeCast.Enabled = false;
 
             float hitboxDepth = CurrentClimber.HitboxDepth;
-            climbingShapeCast.TargetPosition = new Vector3(0f, 0f, hitboxDepth);
+            climbingShapeCast.TargetPosition = new Vector3(0f, 0f, -hitboxDepth);
 
             BoxShape3D shapeCastBox = new BoxShape3D();
             shapeCastBox.Size = new Vector3(CurrentClimber.HitboxWidth, 0f, hitboxDepth);
@@ -430,12 +432,13 @@ namespace Jumpvalley.Players.Movement
                     int collisionCount = climbingShapeCast.GetCollisionCount();
                     float shortestDistance = -1f;
                     Vector3 climbingNormal = Vector3.Zero; // Ladder collision normal
+                    logger.Print($"climbingShapeCast reported {collisionCount} collisions");
                     for (int i = 0; i < collisionCount; i++)
                     {
                         if (Climber.IsClimbable(climbingShapeCast.GetCollider(i)))
                         {
                             // climbing shape-cast's "raycasts" can only travel in the Z axis
-                            float distance = climbingShapeCast.ToLocal(climbingShapeCast.GetCollisionPoint(i)).Z;
+                            float distance = Math.Abs(climbingShapeCast.ToLocal(climbingShapeCast.GetCollisionPoint(i)).Z);
 
                             if (shortestDistance < 0f
                                 || climbingShapeCast.ToLocal(climbingShapeCast.GetCollisionPoint(i)).Z < shortestDistance)

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -768,6 +768,10 @@ namespace Jumpvalley.Players.Movement
             climbingRaycastSweep.Dispose();
             climbingRaycastSweep = null;
 
+            climbingShapeCast.QueueFree();
+            climbingShapeCast.Dispose();
+            climbingShapeCast = null;
+
             base.Dispose();
         }
 

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -428,22 +428,28 @@ namespace Jumpvalley.Players.Movement
                     // we want to use the raycast that "travelled" the smallest distance
                     // as the raycast we're working with.
                     int collisionCount = climbingShapeCast.GetCollisionCount();
-                    float shortestDistance = -1;
-                    RayCast3D selectedRaycast = null;
+                    float shortestDistance = -1f;
+                    Vector3 climbingNormal = Vector3.Zero; // Ladder collision normal
                     for (int i = 0; i < collisionCount; i++)
                     {
-                        
+                        if (Climber.IsClimbable(climbingShapeCast.GetCollider(i)))
+                        {
+                            // climbing shape-cast's "raycasts" can only travel in the Z axis
+                            float distance = climbingShapeCast.ToLocal(climbingShapeCast.GetCollisionPoint(i)).Z;
+
+                            if (shortestDistance < 0f
+                                || climbingShapeCast.ToLocal(climbingShapeCast.GetCollisionPoint(i)).Z < shortestDistance)
+                            {
+                                climbingNormal = climbingShapeCast.GetCollisionNormal(i);
+                                shortestDistance = distance;
+                            }
+                        }
                     }
 
-                    if (selectedRaycast != null)
+                    // shortestDistance is only less than zero if we haven't
+                    // found a ladder collision normal
+                    if (shortestDistance >= 0f)
                     {
-                        RaycastSweepResult raycastSweepResult = new RaycastSweepResult(
-                            selectedRaycast,
-                            selectedRaycast.GetCollisionPoint(),
-                            selectedRaycast.GetCollider(),
-                            0);
-
-                        Vector3 climbingNormal = raycastSweepResult.Raycast.GetCollisionNormal();
 
                         // Get the angles we need to compare normal with move direction,
                         // and do the math as needed according to what was put in the Jumpvalley wiki

--- a/src/core/Players/Movement/BaseMover.cs
+++ b/src/core/Players/Movement/BaseMover.cs
@@ -315,7 +315,7 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         private ShapeCast3D climbingShapeCast;
 
-        //private ConsoleLogger logger;
+        private ConsoleLogger logger;
 
         /// <summary>
         /// Constructs a new instance of BaseMover that can be used to handle character movement
@@ -341,7 +341,7 @@ namespace Jumpvalley.Players.Movement
 
             AddChild(CurrentClimber);
 
-            //logger = new ConsoleLogger(nameof(ConsoleLogger));
+            logger = new ConsoleLogger(nameof(BaseMover));
         }
 
         /// <summary>
@@ -671,7 +671,7 @@ namespace Jumpvalley.Players.Movement
                 )
                 {
                     finalVelocity = moveVelocity;
-                    //logger.Print("Snapped velocity");
+                    logger.Print("Snapped velocity");
                 }
 
                 body.Velocity = finalVelocity;

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -111,16 +111,16 @@ namespace Jumpvalley.Players.Movement
         }
 
         /// <summary>
-        /// Returns whether or not the given <see cref="PhysicsBody3D"/>
+        /// Returns whether or not the given <see cref="Node"/>
         /// can be climbed.
         /// </summary>
-        /// <param name="body">The physics body to check</param>
+        /// <param name="node">The node to check</param>
         /// <returns></returns>
-        public static bool IsClimbable(PhysicsBody3D body)
+        public static bool IsClimbable(Node node)
         {
-            return body != null
-                    && body.HasMeta(IS_CLIMBABLE_METADATA_NAME)
-                    && body.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
+            return node is PhysicsBody3D
+                    && node.HasMeta(IS_CLIMBABLE_METADATA_NAME)
+                    && node.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
         }
 
         /// <summary>

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -92,8 +92,6 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         public float HitboxDepth = 0.2f;
 
-        public float HitboxZOffset = 0.005f;
-
         /// <summary>
         /// Creates a new instance of <see cref="Climber"/>
         /// </summary>

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -111,16 +111,16 @@ namespace Jumpvalley.Players.Movement
         }
 
         /// <summary>
-        /// Returns whether or not the given <see cref="Node"/>
+        /// Returns whether or not the given <see cref="GodotObject"/>
         /// can be climbed.
         /// </summary>
-        /// <param name="node">The node to check</param>
+        /// <param name="obj">The node to check</param>
         /// <returns></returns>
-        public static bool IsClimbable(Node node)
+        public static bool IsClimbable(GodotObject obj)
         {
-            return node is PhysicsBody3D
-                    && node.HasMeta(IS_CLIMBABLE_METADATA_NAME)
-                    && node.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
+            return obj != null
+                    && obj.HasMeta(IS_CLIMBABLE_METADATA_NAME)
+                    && obj.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
         }
 
         /// <summary>

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -12,7 +12,7 @@ namespace Jumpvalley.Players.Movement
         /// <summary>
         /// Name of the metadata entry that specifies whether or not a <see cref="PhysicsBody3D"/> is climbable
         /// </summary>
-        public readonly string IS_CLIMBABLE_METADATA_NAME = "is_climbable";
+        public static readonly string IS_CLIMBABLE_METADATA_NAME = "is_climbable";
 
         /// <summary>
         /// The <see cref="Area3D"/> that allows the character to climb when a climbable PhysicsBody3D is intersecting with it
@@ -111,6 +111,19 @@ namespace Jumpvalley.Players.Movement
         }
 
         /// <summary>
+        /// Returns whether or not the given <see cref="PhysicsBody3D"/>
+        /// can be climbed.
+        /// </summary>
+        /// <param name="body">The physics body to check</param>
+        /// <returns></returns>
+        public static bool IsClimbable(PhysicsBody3D body)
+        {
+            return body != null
+                    && body.HasMeta(IS_CLIMBABLE_METADATA_NAME)
+                    && body.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
+        }
+
+        /// <summary>
         /// Disposes of this <see cref="Climber"/> object and the <see cref="RayCast3D"/> instance being used to power it
         /// </summary>
         public new void Dispose()
@@ -153,9 +166,7 @@ namespace Jumpvalley.Players.Movement
                 {
                     // If the collided object is a PhysicsBody3D and it has a metadata entry
                     // named "is_climbable" set to true, we can climb.
-                    canClimb = collidedObject != null
-                        && collidedObject.HasMeta(IS_CLIMBABLE_METADATA_NAME)
-                        && collidedObject.GetMeta(IS_CLIMBABLE_METADATA_NAME).AsBool() == true;
+                    canClimb = IsClimbable(collidedObject);
 
                     if (canClimb)
                     {

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -72,7 +72,7 @@ namespace Jumpvalley.Players.Movement
                 }
 
                 _hitbox = value;
-                
+
                 if (value != null)
                 {
                     value.AddChild(area);

--- a/src/core/Players/Movement/Climber.cs
+++ b/src/core/Players/Movement/Climber.cs
@@ -17,10 +17,10 @@ namespace Jumpvalley.Players.Movement
         /// <summary>
         /// The <see cref="Area3D"/> that allows the character to climb when a climbable PhysicsBody3D is intersecting with it
         /// </summary>
-        private Area3D area;
+        public Area3D Area { get; private set; }
 
         /// <summary>
-        /// The box that defines <see cref="area"/>'s region
+        /// The box that defines <see cref="Area"/>'s region
         /// </summary>
         private BoxShape3D areaBox;
 
@@ -68,14 +68,14 @@ namespace Jumpvalley.Players.Movement
                 CollisionShape3D oldHitbox = _hitbox;
                 if (oldHitbox != null)
                 {
-                    oldHitbox.RemoveChild(area);
+                    oldHitbox.RemoveChild(Area);
                 }
 
                 _hitbox = value;
 
                 if (value != null)
                 {
-                    value.AddChild(area);
+                    value.AddChild(Area);
                 }
             }
         }
@@ -92,18 +92,20 @@ namespace Jumpvalley.Players.Movement
         /// </summary>
         public float HitboxDepth = 0.2f;
 
+        public float HitboxZOffset = 0.005f;
+
         /// <summary>
         /// Creates a new instance of <see cref="Climber"/>
         /// </summary>
         public Climber(CollisionShape3D hitbox)
         {
-            area = new Area3D();
+            Area = new Area3D();
 
             areaBox = new BoxShape3D();
 
             CollisionShape3D areaShape = new CollisionShape3D();
             areaShape.Shape = areaBox;
-            area.AddChild(areaShape);
+            Area.AddChild(areaShape);
 
             Hitbox = hitbox;
 
@@ -129,8 +131,8 @@ namespace Jumpvalley.Players.Movement
         public new void Dispose()
         {
             QueueFree();
-            area.QueueFree();
-            area.Dispose();
+            Area.QueueFree();
+            Area.Dispose();
             base.Dispose();
         }
 
@@ -148,7 +150,7 @@ namespace Jumpvalley.Players.Movement
             areaBox.Size = new Vector3(HitboxWidth, hitboxSize.Y / 2, HitboxDepth);
 
             // Remember, position of the area is relative to the position of the hitbox.
-            area.Position = new Vector3(0, -hitboxSize.Y / 4, -hitboxSize.Z / 2 - areaBox.Size.Z / 2);
+            Area.Position = new Vector3(0, -hitboxSize.Y / 4, -hitboxSize.Z / 2 - areaBox.Size.Z / 2);
         }
 
         public override void _PhysicsProcess(double delta)
@@ -158,7 +160,7 @@ namespace Jumpvalley.Players.Movement
             updateArea();
 
             bool canClimb = false;
-            foreach (Node3D n in area.GetOverlappingBodies())
+            foreach (Node3D n in Area.GetOverlappingBodies())
             {
                 PhysicsBody3D collidedObject = n as PhysicsBody3D;
 


### PR DESCRIPTION
Fixes #27.

This should make climbing logic work better with ladders that aren't fully solid (e.g. they have gaps between them or the collision shapes used to make the ladder are separated from each other).

This PR also makes a few changes to the `Climber` class.