### PR TITLE
Adjust character body displayed height

### DIFF
--- a/scenes/player/character.tscn
+++ b/scenes/player/character.tscn
@@ -35,4 +35,4 @@ skeleton = NodePath("../..")
 [node name="CharacterBody" parent="." instance=ExtResource("2_3ohbj")]
 
 [node name="CameraFocus" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.75, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.775, 0)

--- a/scenes/player/character_body.tscn
+++ b/scenes/player/character_body.tscn
@@ -11,7 +11,7 @@ radius = 0.15
 height = 0.75
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_d4gh2"]
-height = 1.5
+height = 1.55
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u5oda"]
 albedo_color = Color(0.152941, 0.152941, 0.152941, 1)
@@ -51,7 +51,7 @@ mesh = SubResource("CapsuleMesh_mx087")
 skeleton = NodePath("")
 
 [node name="Torso" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.275, 0)
 
 [node name="Mesh" type="MeshInstance3D" parent="Torso"]
 material_override = ExtResource("1_jhmwb")
@@ -66,7 +66,7 @@ visible = false
 skeleton = NodePath("../../..")
 
 [node name="Face" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0642553, 0.591883, -0.443492)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.064, 0.617, -0.443)
 
 [node name="Mesh" type="MeshInstance3D" parent="Face"]
 transform = Transform3D(-1.31134e-07, 3, 0, -3, -1.31134e-07, 0, 0, 0, 3, 0, 0, 0)


### PR DESCRIPTION
The *displayed* height of the character has been increased in this PR to reflect the new safe-collision-margin size (as was implemented in PR #123). This also adjusts the position of the camera focus to be slightly higher.

**This is a cosmetic change which doesn't affect character physics in any way.**